### PR TITLE
Allow zoom to 1/32.

### DIFF
--- a/src/vikviewport.h
+++ b/src/vikviewport.h
@@ -40,7 +40,7 @@ G_BEGIN_DECLS
 #define VIK_IS_VIEWPORT_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), VIK_VIEWPORT_TYPE))
 
 #define VIK_VIEWPORT_MAX_ZOOM 32768.0
-#define VIK_VIEWPORT_MIN_ZOOM 0.125
+#define VIK_VIEWPORT_MIN_ZOOM (1 / 32.0)
 
 /* used for coord to screen etc, screen to coord */
 #define VIK_VIEWPORT_UTM_WRONG_ZONE -9999999


### PR DESCRIPTION
Sometimes I want to look at a track in fine detail, perhaps to
understand quantization.  I find the default limit of 1/8 meter per
pixel too constraining, and I don't find allowing the user to zoom in
a bit to be problematic.
