### PR TITLE
Please make the build reproducible

### DIFF
--- a/src/icons/Makefile.am
+++ b/src/icons/Makefile.am
@@ -267,7 +267,7 @@ icons.h: $(ALL_ICONS_HEADER)
 icons.c: $(ALL_ICONS_HEADER)
 	echo "/* Generated file */" > $@
 	echo "#include <gdk-pixbuf/gdk-pixdata.h>" >> $@
-	for file in *_pixmap.h ; do echo "#include \"$$file\"" >> $@ ; done
+	for file in $(ALL_ICONS_HEADER) ; do echo "#include \"$$file\"" >> $@ ; done
 
 $(BUILT_SOURCES): $(srcdir)/Makefile.am
 


### PR DESCRIPTION
This patch fixes the order for headers inclusion in icons.c, to get reproducible build. The *_pixmap.h wildcard matches the same files, but with a random order, so that different builds can lead to different binary files.
See https://wiki.debian.org/ReproducibleBuilds/