### PR TITLE
Open files in selected layer

### DIFF
--- a/src/file.h
+++ b/src/file.h
@@ -58,7 +58,7 @@ typedef enum {
 
 gchar *append_file_ext ( const gchar *filename, VikFileType_t type );
 
-VikLoadType_t a_file_load ( VikAggregateLayer *top, VikViewport *vp, const gchar *filename );
+VikLoadType_t a_file_load ( VikAggregateLayer *top, VikViewport *vp, VikTrwLayer *vtl, const gchar *filename );
 gboolean a_file_save ( VikAggregateLayer *top, gpointer vp, const gchar *filename );
 /* Only need to define VikTrack if the file type is FILE_TYPE_GPX_TRACK */
 gboolean a_file_export ( VikTrwLayer *vtl, const gchar *filename, VikFileType_t file_type, VikTrack *trk, gboolean write_hidden );

--- a/src/vikwindow.c
+++ b/src/vikwindow.c
@@ -3100,8 +3100,7 @@ void vik_window_open_file ( VikWindow *vw, const gchar *filename, gboolean chang
   vw->filename = g_strdup ( filename );
   gboolean success = FALSE;
   gboolean restore_original_filename = FALSE;
-
-  vw->loaded_type = a_file_load ( vik_layers_panel_get_top_layer(vw->viking_vlp), vw->viking_vvp, filename );
+  vw->loaded_type = a_file_load ( vik_layers_panel_get_top_layer(vw->viking_vlp), vw->viking_vvp, vw->containing_vtl, filename );
   switch ( vw->loaded_type )
   {
     case LOAD_TYPE_READ_FAILURE:


### PR DESCRIPTION
This issue is found when I try to import GPX file with spaces and Chinese in its name. GPSBabel always fails with space, frequently fails with Chinese, and can not import multiple files in one call. Finally I find a way to import all my year 2016 bike tracks(100+) by opening them all in selected layer. These changes are for the following workflow:
    Open Side Panel.
    Click an existing layer, e.g. My Bike Tracks.
    File->Open. Select multiple GPX files. OK.
    All GPX tracks are added to Top Layer->My Bike Tracks->Tracks.
