### PR TITLE
option to use pace

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -66,7 +66,7 @@ gint viking_version_to_number ( gchar *version )
 
 static gchar * params_degree_formats[] = {N_("DDD"), N_("DMM"), N_("DMS"), N_("Raw"), NULL};
 static gchar * params_units_distance[] = {N_("Kilometres"), N_("Miles"), N_("Nautical Miles"), NULL};
-static gchar * params_units_speed[] = {N_("km/h"), N_("mph"), N_("m/s"), N_("knots"), NULL};
+static gchar * params_units_speed[] = {N_("km/h"), N_("mph"), N_("m/s"), N_("knots"), N_("s/km"), N_("min/km"), N_("s/mi"), N_("min/mi"), NULL};
 static gchar * params_units_height[] = {N_("Metres"), N_("Feet"), NULL};
 static VikLayerParamScale params_scales_lat[] = { {-90.0, 90.0, 0.05, 2} };
 static VikLayerParamScale params_scales_long[] = { {-180.0, 180.0, 0.05, 2} };

--- a/src/globals.h
+++ b/src/globals.h
@@ -57,6 +57,33 @@ G_BEGIN_DECLS
 #define VIK_MPS_TO_KPH(X) ((X)*VIK_KPH_IN_MPS)
 #define VIK_KPH_TO_MPS(X) ((X)/VIK_KPH_IN_MPS)
 
+/* Pace is a running unit of "speed" basically defined as the
+time it takes to cover a given distance. It is useful for two
+reasons: first, usually the distance to cover is fixed and
+therefore the needed time can be found with a multiplication
+(instead of a division) which is easy to perform by mind;
+second, it is more sensitive to small differences, so it is
+useful in races when differences between getting the podium
+or not often depends on small differences in speed.
+
+Note that pace is infinite for speed=0, or very large
+for very small speeds, which are usually not interesting
+cases to analyze for a runner. To avoid overflows, and to
+avoid the graph y-scale being overwhelmed by these numbers,
+a cutting at 60s/km or equivalent (in other units) has been set*/
+
+/* PACE_SPK, Seconds per Kilometer */
+#define VIK_MPS_TO_PACE_SPK(X) ((X) > 1.?  3600./(X)      : 0)
+
+/* PACE_MPK, Minutes per Kilometer */
+#define VIK_MPS_TO_PACE_MPK(X) ((X) > 1.?  60./(X)        : 0)
+
+/* PACE_SPM, Seconds per Mile */
+#define VIK_MPS_TO_PACE_SPM(X) ((X) > 1.?  5793.6384 /(X) : 0)
+
+/* PACE_MPM, Minutes per Mile */
+#define VIK_MPS_TO_PACE_MPM(X) ((X) > 1.?  96.56064 /(X)  : 0)
+
 #define VIK_KNOTS_IN_MPS 1.94384449
 #define VIK_MPS_TO_KNOTS(X) ((X)*VIK_KNOTS_IN_MPS)
 #define VIK_KNOTS_TO_MPS(X) ((X)/VIK_KNOTS_IN_MPS)
@@ -113,6 +140,10 @@ typedef enum {
   VIK_UNITS_SPEED_MILES_PER_HOUR,
   VIK_UNITS_SPEED_METRES_PER_SECOND,
   VIK_UNITS_SPEED_KNOTS,
+  VIK_UNITS_SPEED_SECONDS_PER_KM,
+  VIK_UNITS_SPEED_MINUTES_PER_KM,
+  VIK_UNITS_SPEED_SECONDS_PER_MILE,
+  VIK_UNITS_SPEED_MINUTES_PER_MILE,
 } vik_units_speed_t;
 
 vik_units_speed_t a_vik_get_units_speed ( );

--- a/src/globals.h
+++ b/src/globals.h
@@ -73,16 +73,16 @@ avoid the graph y-scale being overwhelmed by these numbers,
 a cutting at 60s/km or equivalent (in other units) has been set*/
 
 /* PACE_SPK, Seconds per Kilometer */
-#define VIK_MPS_TO_PACE_SPK(X) ((X) > 1.?  3600./(X)      : 0)
+#define VIK_MPS_TO_PACE_SPK(X) ((X) > 1.0 ?  3600./((X)      * VIK_KPH_IN_MPS) : 0)
 
 /* PACE_MPK, Minutes per Kilometer */
-#define VIK_MPS_TO_PACE_MPK(X) ((X) > 1.?  60./(X)        : 0)
+#define VIK_MPS_TO_PACE_MPK(X) ((X) > 1.0 ?  60./((X)        * VIK_KPH_IN_MPS) : 0)
 
 /* PACE_SPM, Seconds per Mile */
-#define VIK_MPS_TO_PACE_SPM(X) ((X) > 1.?  5793.6384 /(X) : 0)
+#define VIK_MPS_TO_PACE_SPM(X) ((X) > 1.0 ?  5793.6384 /((X) * VIK_KPH_IN_MPS) : 0)
 
 /* PACE_MPM, Minutes per Mile */
-#define VIK_MPS_TO_PACE_MPM(X) ((X) > 1.?  96.56064 /(X)  : 0)
+#define VIK_MPS_TO_PACE_MPM(X) ((X) > 1.0 ?  96.56064 /((X)  * VIK_KPH_IN_MPS) : 0)
 
 #define VIK_KNOTS_IN_MPS 1.94384449
 #define VIK_MPS_TO_KNOTS(X) ((X)*VIK_KNOTS_IN_MPS)

--- a/src/viktrwlayer_analysis.c
+++ b/src/viktrwlayer_analysis.c
@@ -321,6 +321,46 @@ static void table_output ( track_stats ts, GtkWidget *content[] )
 		else
 			g_snprintf ( tmp_buf, sizeof(tmp_buf), "--" );
 		break;
+        case VIK_UNITS_SPEED_SECONDS_PER_KM:
+		if ( ts.max_speed > 0 )
+			g_snprintf ( tmp_buf, sizeof(tmp_buf), _("%d s/km\n"), (int)VIK_MPS_TO_PACE_SPK(ts.max_speed) );
+		gtk_label_set_text ( GTK_LABEL(content[cnt++]), tmp_buf );
+		if ( ts.duration > 0 )
+			g_snprintf ( tmp_buf, sizeof(tmp_buf), _("%d s/km"), (int)VIK_MPS_TO_PACE_SPK(ts.length/ts.duration) );
+		else
+			g_snprintf ( tmp_buf, sizeof(tmp_buf), "--" );
+		break;
+
+        case VIK_UNITS_SPEED_MINUTES_PER_KM:
+		if ( ts.max_speed > 0 )
+			g_snprintf ( tmp_buf, sizeof(tmp_buf), _("%.1f min/km\n"), (double)VIK_MPS_TO_PACE_MPK(ts.max_speed) );
+		gtk_label_set_text ( GTK_LABEL(content[cnt++]), tmp_buf );
+		if ( ts.duration > 0 )
+			g_snprintf ( tmp_buf, sizeof(tmp_buf), _("%.1f min/km"), (double)VIK_MPS_TO_PACE_MPK(ts.length/ts.duration) );
+		else
+			g_snprintf ( tmp_buf, sizeof(tmp_buf), "--" );
+		break;
+
+        case VIK_UNITS_SPEED_SECONDS_PER_MILE:
+		if ( ts.max_speed > 0 )
+			g_snprintf ( tmp_buf, sizeof(tmp_buf), _("%d sec/mi\n"), (int)VIK_MPS_TO_PACE_SPM(ts.max_speed) );
+		gtk_label_set_text ( GTK_LABEL(content[cnt++]), tmp_buf );
+		if ( ts.duration > 0 )
+			g_snprintf ( tmp_buf, sizeof(tmp_buf), _("%d sec/mi"), (int)VIK_MPS_TO_PACE_SPM(ts.length/ts.duration) );
+		else
+			g_snprintf ( tmp_buf, sizeof(tmp_buf), "--" );
+		break;
+
+        case VIK_UNITS_SPEED_MINUTES_PER_MILE:
+		if ( ts.max_speed > 0 )
+			g_snprintf ( tmp_buf, sizeof(tmp_buf), _("%.1f min/mi\n"), (double)VIK_MPS_TO_PACE_MPM(ts.max_speed) );
+		gtk_label_set_text ( GTK_LABEL(content[cnt++]), tmp_buf );
+		if ( ts.duration > 0 )
+			g_snprintf ( tmp_buf, sizeof(tmp_buf), _("%.1f min/mi"), (double)VIK_MPS_TO_PACE_MPM(ts.length/ts.duration) );
+		else
+			g_snprintf ( tmp_buf, sizeof(tmp_buf), "--" );
+		break;
+
 	default:
 		//VIK_UNITS_SPEED_KILOMETRES_PER_HOUR:
 		if ( ts.max_speed > 0 )

--- a/src/viktrwlayer_propwin.c
+++ b/src/viktrwlayer_propwin.c
@@ -959,6 +959,18 @@ void track_vt_move( GtkWidget *event_box, GdkEventMotion *event, PropWidgets *wi
     case VIK_UNITS_SPEED_KNOTS:
       g_snprintf(tmp_buf, sizeof(tmp_buf), _("%.1f knots"), widgets->speeds[ix]);
       break;
+    case VIK_UNITS_SPEED_SECONDS_PER_KM:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), _("%.1f s/km"), widgets->speeds[ix]);
+      break;
+    case VIK_UNITS_SPEED_MINUTES_PER_KM:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), _("%.1f min/km"), widgets->speeds[ix]);
+      break;
+    case VIK_UNITS_SPEED_SECONDS_PER_MILE:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), _("%.1f sec/mi"), widgets->speeds[ix]);
+      break;
+    case VIK_UNITS_SPEED_MINUTES_PER_MILE:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), _("%.1f min/mi"), widgets->speeds[ix]);
+      break;
     default:
       // VIK_UNITS_SPEED_METRES_PER_SECOND:
       g_snprintf(tmp_buf, sizeof(tmp_buf), _("%.1f m/s"), widgets->speeds[ix]);
@@ -1228,6 +1240,18 @@ void track_sd_move( GtkWidget *event_box, GdkEventMotion *event, PropWidgets *wi
       break;
     case VIK_UNITS_SPEED_KNOTS:
       g_snprintf(tmp_buf, sizeof(tmp_buf), _("%.1f knots"), widgets->speeds_dist[ix]);
+      break;
+    case VIK_UNITS_SPEED_SECONDS_PER_KM:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), _("%.1f s/km"), widgets->speeds_dist[ix]);
+      break;
+    case VIK_UNITS_SPEED_MINUTES_PER_KM:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), _("%.1f min/km"), widgets->speeds_dist[ix]);
+      break;
+    case VIK_UNITS_SPEED_SECONDS_PER_MILE:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), _("%.1f sec/mi"), widgets->speeds_dist[ix]);
+      break;
+    case VIK_UNITS_SPEED_MINUTES_PER_MILE:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), _("%.1f min/mi"), widgets->speeds_dist[ix]);
       break;
     default:
       // VIK_UNITS_SPEED_METRES_PER_SECOND:
@@ -1794,6 +1818,26 @@ static void draw_vt ( GtkWidget *image, VikTrack *tr, PropWidgets *widgets)
       widgets->speeds[i] = VIK_MPS_TO_KNOTS(widgets->speeds[i]);
     }
     break;
+  case VIK_UNITS_SPEED_SECONDS_PER_KM:
+    for ( i = 0; i < widgets->profile_width; i++ ) {
+      widgets->speeds[i] = VIK_MPS_TO_PACE_SPK(widgets->speeds[i]);
+    }
+  break;
+  case VIK_UNITS_SPEED_MINUTES_PER_KM:
+    for ( i = 0; i < widgets->profile_width; i++ ) {
+      widgets->speeds[i] = VIK_MPS_TO_PACE_MPK(widgets->speeds[i]);
+    }
+  break;
+  case VIK_UNITS_SPEED_SECONDS_PER_MILE:
+    for ( i = 0; i < widgets->profile_width; i++ ) {
+      widgets->speeds[i] = VIK_MPS_TO_PACE_SPM(widgets->speeds[i]);
+    }
+  break;
+  case VIK_UNITS_SPEED_MINUTES_PER_MILE:
+    for ( i = 0; i < widgets->profile_width; i++ ) {
+      widgets->speeds[i] = VIK_MPS_TO_PACE_MPM(widgets->speeds[i]);
+    }
+  break;
   default:
     // VIK_UNITS_SPEED_METRES_PER_SECOND:
     // No need to convert as already in m/s
@@ -1836,6 +1880,18 @@ static void draw_vt ( GtkWidget *image, VikTrack *tr, PropWidgets *widgets)
     case VIK_UNITS_SPEED_KNOTS:
       sprintf(s, "%8dknots", (int)(mins + (LINES-i)*chunkss[widgets->cis]));
       break;
+    case VIK_UNITS_SPEED_SECONDS_PER_KM:
+      sprintf(s, "%8ds/km", (int)(mins + (LINES-i)*chunkss[widgets->cis]));
+      break;
+    case VIK_UNITS_SPEED_MINUTES_PER_KM:
+      sprintf(s, "%8dmin/km", (int)(mins + (LINES-i)*chunkss[widgets->cis]));
+      break;
+    case VIK_UNITS_SPEED_SECONDS_PER_MILE:
+      sprintf(s, "%8dsec/mi", (int)(mins + (LINES-i)*chunkss[widgets->cis]));
+      break;
+    case VIK_UNITS_SPEED_MINUTES_PER_MILE:
+      sprintf(s, "%8dmin/mi", (int)(mins + (LINES-i)*chunkss[widgets->cis]));
+      break;
     default:
       sprintf(s, "--");
       g_critical("Houston, we've had a problem. speed=%d", speed_units);
@@ -1876,6 +1932,18 @@ static void draw_vt ( GtkWidget *image, VikTrack *tr, PropWidgets *widgets)
 	break;
       case VIK_UNITS_SPEED_KNOTS:
 	gps_speed = VIK_MPS_TO_KNOTS(gps_speed);
+	break;
+      case VIK_UNITS_SPEED_SECONDS_PER_KM:
+	gps_speed = VIK_MPS_TO_PACE_SPK(gps_speed);
+	break;
+      case VIK_UNITS_SPEED_MINUTES_PER_KM:
+	gps_speed = VIK_MPS_TO_PACE_MPK(gps_speed);
+	break;
+      case VIK_UNITS_SPEED_SECONDS_PER_MILE:
+	gps_speed = VIK_MPS_TO_PACE_SPM(gps_speed);
+	break;
+      case VIK_UNITS_SPEED_MINUTES_PER_MILE:
+	gps_speed = VIK_MPS_TO_PACE_MPM(gps_speed);
 	break;
       default:
 	// VIK_UNITS_SPEED_METRES_PER_SECOND:
@@ -2181,6 +2249,27 @@ static void draw_sd ( GtkWidget *image, VikTrack *tr, PropWidgets *widgets)
       widgets->speeds_dist[i] = VIK_MPS_TO_KNOTS(widgets->speeds_dist[i]);
     }
     break;
+  case VIK_UNITS_SPEED_SECONDS_PER_KM:
+    for ( i = 0; i < widgets->profile_width; i++ ) {
+      widgets->speeds_dist[i] = VIK_MPS_TO_PACE_SPK(widgets->speeds_dist[i]);
+    }
+    break;
+  case VIK_UNITS_SPEED_MINUTES_PER_KM:
+    for ( i = 0; i < widgets->profile_width; i++ ) {
+      widgets->speeds_dist[i] = VIK_MPS_TO_PACE_MPK(widgets->speeds_dist[i]);
+    }
+    break;
+  case VIK_UNITS_SPEED_SECONDS_PER_MILE:
+    for ( i = 0; i < widgets->profile_width; i++ ) {
+      widgets->speeds_dist[i] = VIK_MPS_TO_PACE_SPM(widgets->speeds_dist[i]);
+    }
+    break;
+  case VIK_UNITS_SPEED_MINUTES_PER_MILE:
+    for ( i = 0; i < widgets->profile_width; i++ ) {
+      widgets->speeds_dist[i] = VIK_MPS_TO_PACE_MPM(widgets->speeds_dist[i]);
+    }
+    break;
+
   default:
     // VIK_UNITS_SPEED_METRES_PER_SECOND:
     // No need to convert as already in m/s
@@ -2224,6 +2313,18 @@ static void draw_sd ( GtkWidget *image, VikTrack *tr, PropWidgets *widgets)
     case VIK_UNITS_SPEED_KNOTS:
       sprintf(s, "%8dknots", (int)(mins + (LINES-i)*chunkss[widgets->cisd]));
       break;
+    case VIK_UNITS_SPEED_SECONDS_PER_KM:
+      sprintf(s, "%8ds/km", (int)(mins + (LINES-i)*chunkss[widgets->cisd]));
+      break;
+    case VIK_UNITS_SPEED_MINUTES_PER_KM:
+      sprintf(s, "%8dmin/km", (int)(mins + (LINES-i)*chunkss[widgets->cisd]));
+      break;
+    case VIK_UNITS_SPEED_SECONDS_PER_MILE:
+      sprintf(s, "%8dsec/mi", (int)(mins + (LINES-i)*chunkss[widgets->cisd]));
+      break;
+    case VIK_UNITS_SPEED_MINUTES_PER_MILE:
+      sprintf(s, "%8dmin/mi", (int)(mins + (LINES-i)*chunkss[widgets->cisd]));
+      break;
     default:
       sprintf(s, "--");
       g_critical("Houston, we've had a problem. speed=%d", speed_units);
@@ -2265,6 +2366,18 @@ static void draw_sd ( GtkWidget *image, VikTrack *tr, PropWidgets *widgets)
 	break;
       case VIK_UNITS_SPEED_KNOTS:
 	gps_speed = VIK_MPS_TO_KNOTS(gps_speed);
+	break;
+      case VIK_UNITS_SPEED_SECONDS_PER_KM:
+	gps_speed = VIK_MPS_TO_PACE_SPK(gps_speed);
+	break;
+      case VIK_UNITS_SPEED_MINUTES_PER_KM:
+	gps_speed = VIK_MPS_TO_PACE_MPK(gps_speed);
+	break;
+      case VIK_UNITS_SPEED_SECONDS_PER_MILE:
+	gps_speed = VIK_MPS_TO_PACE_SPM(gps_speed);
+	break;
+      case VIK_UNITS_SPEED_MINUTES_PER_MILE:
+	gps_speed = VIK_MPS_TO_PACE_MPM(gps_speed);
 	break;
       default:
 	// VIK_UNITS_SPEED_METRES_PER_SECOND:
@@ -3259,6 +3372,18 @@ void vik_trw_layer_propwin_run ( GtkWindow *parent,
     case VIK_UNITS_SPEED_KNOTS:
       g_snprintf(tmp_buf, sizeof(tmp_buf), "%.2f knots", VIK_MPS_TO_KNOTS(tmp_speed));
       break;
+    case VIK_UNITS_SPEED_SECONDS_PER_KM:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), "%.2f s/km", VIK_MPS_TO_PACE_SPK(tmp_speed));
+      break;
+    case VIK_UNITS_SPEED_MINUTES_PER_KM:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), "%.2f min/km", VIK_MPS_TO_PACE_MPK(tmp_speed));
+      break;
+    case VIK_UNITS_SPEED_SECONDS_PER_MILE:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), "%.2f sec/mi", VIK_MPS_TO_PACE_SPM(tmp_speed));
+      break;
+    case VIK_UNITS_SPEED_MINUTES_PER_MILE:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), "%.2f min/mi", VIK_MPS_TO_PACE_MPM(tmp_speed));
+      break;
     default:
       g_snprintf (tmp_buf, sizeof(tmp_buf), "--" );
       g_critical("Houston, we've had a problem. speed=%d", speed_units);
@@ -3282,6 +3407,18 @@ void vik_trw_layer_propwin_run ( GtkWindow *parent,
       break;
     case VIK_UNITS_SPEED_KNOTS:
       g_snprintf(tmp_buf, sizeof(tmp_buf), "%.2f knots", VIK_MPS_TO_KNOTS(tmp_speed));
+      break;
+    case VIK_UNITS_SPEED_SECONDS_PER_KM:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), "%.2f s/km", VIK_MPS_TO_PACE_SPK(tmp_speed));
+      break;
+    case VIK_UNITS_SPEED_MINUTES_PER_KM:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), "%.2f min/km", VIK_MPS_TO_PACE_MPK(tmp_speed));
+      break;
+    case VIK_UNITS_SPEED_SECONDS_PER_MILE:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), "%.2f sec/mi", VIK_MPS_TO_PACE_SPM(tmp_speed));
+      break;
+    case VIK_UNITS_SPEED_MINUTES_PER_MILE:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), "%.2f min/mi", VIK_MPS_TO_PACE_MPM(tmp_speed));
       break;
     default:
       g_snprintf (tmp_buf, sizeof(tmp_buf), "--" );
@@ -3310,6 +3447,18 @@ void vik_trw_layer_propwin_run ( GtkWindow *parent,
       break;
     case VIK_UNITS_SPEED_KNOTS:
       g_snprintf(tmp_buf, sizeof(tmp_buf), "%.2f knots", VIK_MPS_TO_KNOTS(tmp_speed));
+      break;
+    case VIK_UNITS_SPEED_SECONDS_PER_KM:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), "%.2f s/km", VIK_MPS_TO_PACE_SPK(tmp_speed));
+      break;
+    case VIK_UNITS_SPEED_MINUTES_PER_KM:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), "%.2f min/km", VIK_MPS_TO_PACE_MPK(tmp_speed));
+      break;
+    case VIK_UNITS_SPEED_SECONDS_PER_MILE:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), "%.2f sec/mi", VIK_MPS_TO_PACE_SPM(tmp_speed));
+      break;
+    case VIK_UNITS_SPEED_MINUTES_PER_MILE:
+      g_snprintf(tmp_buf, sizeof(tmp_buf), "%.2f min/mi", VIK_MPS_TO_PACE_MPM(tmp_speed));
       break;
     default:
       g_snprintf (tmp_buf, sizeof(tmp_buf), "--" );

--- a/src/viktrwlayer_tpwin.c
+++ b/src/viktrwlayer_tpwin.c
@@ -475,6 +475,18 @@ void vik_trw_layer_tpwin_set_tp ( VikTrwLayerTpwin *tpwin, GList *tpl, const gch
 	case VIK_UNITS_SPEED_KNOTS:
 	  g_snprintf ( tmp_str, sizeof(tmp_str), "%.2f knots", VIK_MPS_TO_KNOTS(vik_coord_diff(&(tp->coord), &(tpwin->cur_tp->coord)) / (ABS(tp->timestamp - tpwin->cur_tp->timestamp))) );
 	  break;
+	case VIK_UNITS_SPEED_SECONDS_PER_KM:
+	  g_snprintf ( tmp_str, sizeof(tmp_str), "%.2f s/km", VIK_MPS_TO_PACE_SPK(vik_coord_diff(&(tp->coord), &(tpwin->cur_tp->coord)) / (ABS(tp->timestamp - tpwin->cur_tp->timestamp))) );
+	  break;
+	case VIK_UNITS_SPEED_MINUTES_PER_KM:
+	  g_snprintf ( tmp_str, sizeof(tmp_str), "%.2f min/km", VIK_MPS_TO_PACE_MPK(vik_coord_diff(&(tp->coord), &(tpwin->cur_tp->coord)) / (ABS(tp->timestamp - tpwin->cur_tp->timestamp))) );
+	  break;
+	case VIK_UNITS_SPEED_SECONDS_PER_MILE:
+	  g_snprintf ( tmp_str, sizeof(tmp_str), "%.2f sec/mi", VIK_MPS_TO_PACE_SPM(vik_coord_diff(&(tp->coord), &(tpwin->cur_tp->coord)) / (ABS(tp->timestamp - tpwin->cur_tp->timestamp))) );
+	  break;
+	case VIK_UNITS_SPEED_MINUTES_PER_MILE:
+	  g_snprintf ( tmp_str, sizeof(tmp_str), "%.2f min/mi", VIK_MPS_TO_PACE_MPM(vik_coord_diff(&(tp->coord), &(tpwin->cur_tp->coord)) / (ABS(tp->timestamp - tpwin->cur_tp->timestamp))) );
+	  break;
 	default:
 	  g_snprintf ( tmp_str, sizeof(tmp_str), "--" );
 	  g_critical("Houston, we've had a problem. speed=%d", speed_units);
@@ -507,6 +519,18 @@ void vik_trw_layer_tpwin_set_tp ( VikTrwLayerTpwin *tpwin, GList *tpl, const gch
       break;
     case VIK_UNITS_SPEED_KNOTS:
       g_snprintf ( tmp_str, sizeof(tmp_str), "%.2f knots", VIK_MPS_TO_KNOTS(tp->speed) );
+      break;
+    case VIK_UNITS_SPEED_SECONDS_PER_KM:
+      g_snprintf ( tmp_str, sizeof(tmp_str), "%.2f s/km", VIK_MPS_TO_PACE_SPK(tp->speed) );
+      break;
+    case VIK_UNITS_SPEED_MINUTES_PER_KM:
+      g_snprintf ( tmp_str, sizeof(tmp_str), "%.2f min/km", VIK_MPS_TO_PACE_MPK(tp->speed) );
+      break;
+    case VIK_UNITS_SPEED_SECONDS_PER_MILE:
+      g_snprintf ( tmp_str, sizeof(tmp_str), "%.2f s/mi", VIK_MPS_TO_PACE_SPM(tp->speed) );
+      break;
+    case VIK_UNITS_SPEED_MINUTES_PER_MILE:
+      g_snprintf ( tmp_str, sizeof(tmp_str), "%.2f min/mi", VIK_MPS_TO_PACE_MPM(tp->speed) );
       break;
     default:
       // VIK_UNITS_SPEED_KILOMETRES_PER_HOUR:

--- a/src/viktrwlayer_tracklist.c
+++ b/src/viktrwlayer_tracklist.c
@@ -655,7 +655,7 @@ static void vik_trw_layer_track_list_internal ( GtkWidget *dialog,
 	case VIK_UNITS_SPEED_KILOMETRES_PER_HOUR: spd_units = g_strdup (_("km/h")); break;
 	case VIK_UNITS_SPEED_MILES_PER_HOUR:      spd_units = g_strdup (_("mph")); break;
 	case VIK_UNITS_SPEED_KNOTS:               spd_units = g_strdup (_("knots")); break;
-	case VIK_UNITS_SPEED_SECONDS_PER_KM:      spd_units = g_strdup (_("s/mk")); break;
+	case VIK_UNITS_SPEED_SECONDS_PER_KM:      spd_units = g_strdup (_("s/km")); break;
 	case VIK_UNITS_SPEED_MINUTES_PER_KM:      spd_units = g_strdup (_("min/km")); break;
 	case VIK_UNITS_SPEED_SECONDS_PER_MILE:    spd_units = g_strdup (_("sec/mi")); break;
 	case VIK_UNITS_SPEED_MINUTES_PER_MILE:    spd_units = g_strdup (_("min/mi")); break;

--- a/src/viktrwlayer_tracklist.c
+++ b/src/viktrwlayer_tracklist.c
@@ -477,6 +477,11 @@ static void trw_layer_track_list_add ( vik_trw_track_list_t *vtdl,
 	case VIK_UNITS_SPEED_KILOMETRES_PER_HOUR: av_speed = VIK_MPS_TO_KPH(av_speed); break;
 	case VIK_UNITS_SPEED_MILES_PER_HOUR:      av_speed = VIK_MPS_TO_MPH(av_speed); break;
 	case VIK_UNITS_SPEED_KNOTS:               av_speed = VIK_MPS_TO_KNOTS(av_speed); break;
+	case VIK_UNITS_SPEED_SECONDS_PER_KM:      av_speed = VIK_MPS_TO_PACE_SPK(av_speed); break;
+	case VIK_UNITS_SPEED_MINUTES_PER_KM:      av_speed = VIK_MPS_TO_PACE_MPK(av_speed); break;
+	case VIK_UNITS_SPEED_SECONDS_PER_MILE:    av_speed = VIK_MPS_TO_PACE_SPM(av_speed); break;
+	case VIK_UNITS_SPEED_MINUTES_PER_MILE:    av_speed = VIK_MPS_TO_PACE_MPM(av_speed); break;
+
 	default: // VIK_UNITS_SPEED_METRES_PER_SECOND therefore no change
 		break;
 	}
@@ -486,6 +491,10 @@ static void trw_layer_track_list_add ( vik_trw_track_list_t *vtdl,
 	case VIK_UNITS_SPEED_KILOMETRES_PER_HOUR: max_speed = VIK_MPS_TO_KPH(max_speed); break;
 	case VIK_UNITS_SPEED_MILES_PER_HOUR:      max_speed = VIK_MPS_TO_MPH(max_speed); break;
 	case VIK_UNITS_SPEED_KNOTS:               max_speed = VIK_MPS_TO_KNOTS(max_speed); break;
+	case VIK_UNITS_SPEED_SECONDS_PER_KM:      max_speed = VIK_MPS_TO_PACE_SPK(max_speed); break;
+	case VIK_UNITS_SPEED_MINUTES_PER_KM:      max_speed = VIK_MPS_TO_PACE_MPK(max_speed); break;
+	case VIK_UNITS_SPEED_SECONDS_PER_MILE:    max_speed = VIK_MPS_TO_PACE_SPM(max_speed); break;
+	case VIK_UNITS_SPEED_MINUTES_PER_MILE:    max_speed = VIK_MPS_TO_PACE_MPM(max_speed); break;
 	default: // VIK_UNITS_SPEED_METRES_PER_SECOND therefore no change
 		break;
 	}
@@ -646,6 +655,10 @@ static void vik_trw_layer_track_list_internal ( GtkWidget *dialog,
 	case VIK_UNITS_SPEED_KILOMETRES_PER_HOUR: spd_units = g_strdup (_("km/h")); break;
 	case VIK_UNITS_SPEED_MILES_PER_HOUR:      spd_units = g_strdup (_("mph")); break;
 	case VIK_UNITS_SPEED_KNOTS:               spd_units = g_strdup (_("knots")); break;
+	case VIK_UNITS_SPEED_SECONDS_PER_KM:      spd_units = g_strdup (_("s/mk")); break;
+	case VIK_UNITS_SPEED_MINUTES_PER_KM:      spd_units = g_strdup (_("min/km")); break;
+	case VIK_UNITS_SPEED_SECONDS_PER_MILE:    spd_units = g_strdup (_("sec/mi")); break;
+	case VIK_UNITS_SPEED_MINUTES_PER_MILE:    spd_units = g_strdup (_("min/mi")); break;
 	// VIK_UNITS_SPEED_METRES_PER_SECOND:
 	default:                                  spd_units = g_strdup (_("m/s")); break;
 	}

--- a/src/vikutils.c
+++ b/src/vikutils.c
@@ -83,6 +83,18 @@ gchar* vu_trackpoint_formatted_message ( gchar *format_code, VikTrackpoint *trkp
 	case VIK_UNITS_SPEED_KNOTS:
 		speed_units_str = g_strdup ( _("knots") );
 		break;
+	case VIK_UNITS_SPEED_SECONDS_PER_KM:
+		speed_units_str = g_strdup ( _("s/km") );
+		break;
+	case VIK_UNITS_SPEED_MINUTES_PER_KM:
+		speed_units_str = g_strdup ( _("min/km") );
+		break;
+	case VIK_UNITS_SPEED_SECONDS_PER_MILE:
+		speed_units_str = g_strdup ( _("sec/mi") );
+		break;
+	case VIK_UNITS_SPEED_MINUTES_PER_MILE:
+		speed_units_str = g_strdup ( _("min/mi") );
+		break;
 	default:
 		// VIK_UNITS_SPEED_KILOMETRES_PER_HOUR:
 		speed_units_str = g_strdup ( _("km/h") );
@@ -127,6 +139,18 @@ gchar* vu_trackpoint_formatted_message ( gchar *format_code, VikTrackpoint *trkp
 			case VIK_UNITS_SPEED_KNOTS:
 				speed = VIK_MPS_TO_KNOTS(speed);
 				break;
+			case VIK_UNITS_SPEED_SECONDS_PER_KM:
+				speed = VIK_MPS_TO_PACE_SPK(speed);
+				break;
+			case VIK_UNITS_SPEED_MINUTES_PER_KM:
+				speed = VIK_MPS_TO_PACE_MPK(speed);
+				break;
+			case VIK_UNITS_SPEED_SECONDS_PER_MILE:
+				speed = VIK_MPS_TO_PACE_SPM(speed);
+				break;
+			case VIK_UNITS_SPEED_MINUTES_PER_MILE:
+				speed = VIK_MPS_TO_PACE_SPK(speed);
+				break;
 			default:
 				// VIK_UNITS_SPEED_METRES_PER_SECOND:
 				// Already in m/s so nothing to do
@@ -168,6 +192,18 @@ gchar* vu_trackpoint_formatted_message ( gchar *format_code, VikTrackpoint *trkp
 				break;
 			case VIK_UNITS_SPEED_KNOTS:
 				speed = VIK_MPS_TO_KNOTS(speed);
+				break;
+			case VIK_UNITS_SPEED_SECONDS_PER_KM:
+				speed = VIK_MPS_TO_PACE_SPK(speed);
+				break;
+			case VIK_UNITS_SPEED_MINUTES_PER_KM:
+				speed = VIK_MPS_TO_PACE_MPK(speed);
+				break;
+			case VIK_UNITS_SPEED_SECONDS_PER_MILE:
+				speed = VIK_MPS_TO_PACE_SPM(speed);
+				break;
+			case VIK_UNITS_SPEED_MINUTES_PER_MILE:
+				speed = VIK_MPS_TO_PACE_SPK(speed);
 				break;
 			default:
 				// VIK_UNITS_SPEED_METRES_PER_SECOND:


### PR DESCRIPTION
I was hoping to include the pace (inverse of speed) with not these many lines of codes, but to do so I should have refactored many pieces of the existing infrastructure which has a fair bit of repetition. Instead, I opted for keeping the same infrastructure (and repetitions) as is, and duplicate it for the pace.

Moreover, the pace is a time over a fixed distance, and is usually shown as `minute:seconds`. To do so, I would have to change many things, including how the labels for the y axis are created in the plotting library, using strings instead of number. Instead, I choose to give the user the option to select either minutes or seconds (per either km or miles) and keeping them numbers instead of having to mess up with strings.

Last, but not least, being pace the inverse of speed, it diverges when one is not moving, which is exactly what one wants (how long would it take to cover a mile if you are standing still? It would take forever, or infinity -- how long if you are going slower than ant's step? Again *almost* forever or a very large number). Therefore, like in all systems that use pace, I set a threshold in `globals.h`, above which pace is not computed/plotted.

In the end, it seems to be working well.