### PR TITLE
Add support for Brouter routing service

### DIFF
--- a/data/routing.xml
+++ b/data/routing.xml
@@ -15,5 +15,14 @@
     <property name="url-start-ll">&amp;flat=%s&amp;flon=%s</property>
     <property name="url-stop-ll">&amp;tlat=%s&amp;tlon=%s&amp;v=bicycle&amp;fast=1&amp;layer=mapnik</property>
   </object>
+  <object class="VikRoutingWebEngine">
+    <property name="id">brouter</property>
+    <property name="label">brouter</property>
+    <property name="format">gpx</property>
+    <property name="url-base">http://h2096617.stratoserver.net:443/brouter?nogos=&amp;profile=hiking-beta&amp;alternativeidx=0&amp;format=gpx</property>
+    <property name="url-start-ll">&amp;lonlats=%s,%s</property>
+    <property name="url-stop-ll">|%s,%s</property>
+    <property name="url-via-ll"></property>
+    <property name="url-ll-lat-first">FALSE</property>
+  </object>
 </objects>
-


### PR DESCRIPTION
By using a new property as discussed in #37 this patch permits to use web routing engines that take coordinates in longitude,latitude format (instead of default latitude,longitute).
A configuration for the Brouter web engine, that uses this format, is provided.