### PR TITLE
Change of search to present a list of results

### DIFF
--- a/src/geonames.c
+++ b/src/geonames.c
@@ -33,9 +33,10 @@
 void geonames_init () {
   // Goto
   VikGotoXmlTool *geonames = VIK_GOTO_XML_TOOL ( g_object_new ( VIK_GOTO_XML_TOOL_TYPE, "label", "Geonames",
-    "url-format", "http://api.geonames.org/search?q=%s&maxRows=1&lang=en&style=short&username="VIK_CONFIG_GEONAMES_USERNAME,
+    "url-format", "http://api.geonames.org/search?q=%s&lang=en&style=short&username="VIK_CONFIG_GEONAMES_USERNAME,
     "lat-path", "/geonames/geoname/lat",
     "lon-path", "/geonames/geoname/lng",
+    "desc-path", "/geonames/geoname/toponymName",
     NULL ) );
     vik_goto_register ( VIK_GOTO_TOOL ( geonames ) );
     g_object_unref ( geonames );

--- a/src/google.c
+++ b/src/google.c
@@ -44,6 +44,9 @@ void google_init () {
   /*
    * Google no longer supports the API we used
    *
+   * If this is reinstated, implement
+   * google_goto_tool_parse_file_for_candidates in googlesearch.c
+   *
   GoogleGotoTool *gototool = google_goto_tool_new (  );
   vik_goto_register ( VIK_GOTO_TOOL ( gototool ) );
   g_object_unref ( gototool );

--- a/src/googlesearch.c
+++ b/src/googlesearch.c
@@ -51,6 +51,7 @@ static void google_goto_tool_finalize ( GObject *gob );
 static gchar *google_goto_tool_get_url_format ( VikGotoTool *self );
 static DownloadFileOptions *google_goto_tool_get_download_options ( VikGotoTool *self );
 static gboolean google_goto_tool_parse_file_for_latlon(VikGotoTool *self, gchar *filename, struct LatLon *ll);
+static gboolean google_goto_tool_parse_file_for_candidates(VikGotoTool *self, gchar *filename, GList *candidates);
 
 G_DEFINE_TYPE (GoogleGotoTool, google_goto_tool, VIK_GOTO_TOOL_TYPE)
 
@@ -68,6 +69,7 @@ static void google_goto_tool_class_init ( GoogleGotoToolClass *klass )
   parent_class->get_url_format = google_goto_tool_get_url_format;
   parent_class->get_download_options = google_goto_tool_get_download_options;
   parent_class->parse_file_for_latlon = google_goto_tool_parse_file_for_latlon;
+  parent_class->parse_file_for_candidates = google_goto_tool_parse_file_for_candidates;
 }
 
 GoogleGotoTool *google_goto_tool_new ()
@@ -150,6 +152,12 @@ done:
   g_mapped_file_unref(mf);
   return (found);
 
+}
+
+// TODO: implement this -- The Google API is currently disabled
+static gboolean google_goto_tool_parse_file_for_candidates(VikGotoTool *self, gchar *file_name, GList *candidates)
+{
+  return FALSE;
 }
 
 static gchar *google_goto_tool_get_url_format ( VikGotoTool *self )

--- a/src/googlesearch.c
+++ b/src/googlesearch.c
@@ -51,7 +51,7 @@ static void google_goto_tool_finalize ( GObject *gob );
 static gchar *google_goto_tool_get_url_format ( VikGotoTool *self );
 static DownloadFileOptions *google_goto_tool_get_download_options ( VikGotoTool *self );
 static gboolean google_goto_tool_parse_file_for_latlon(VikGotoTool *self, gchar *filename, struct LatLon *ll);
-static gboolean google_goto_tool_parse_file_for_candidates(VikGotoTool *self, gchar *filename, GList *candidates);
+static gboolean google_goto_tool_parse_file_for_candidates(VikGotoTool *self, gchar *filename, GList **candidates);
 
 G_DEFINE_TYPE (GoogleGotoTool, google_goto_tool, VIK_GOTO_TOOL_TYPE)
 
@@ -155,7 +155,7 @@ done:
 }
 
 // TODO: implement this -- The Google API is currently disabled
-static gboolean google_goto_tool_parse_file_for_candidates(VikGotoTool *self, gchar *file_name, GList *candidates)
+static gboolean google_goto_tool_parse_file_for_candidates(VikGotoTool *self, gchar *file_name, GList **candidates)
 {
   return FALSE;
 }

--- a/src/osm.c
+++ b/src/osm.c
@@ -211,19 +211,11 @@ void osm_init () {
     "lat-attr", "lat",
     "lon-path", "/searchresults/place",
     "lon-attr", "lon",
+    "desc-path", "/searchresults/place",
+    "desc-attr", "display_name",
     NULL ) );
     vik_goto_register ( VIK_GOTO_TOOL ( nominatim ) );
     g_object_unref ( nominatim );
-
-  VikGotoXmlTool *namefinder = VIK_GOTO_XML_TOOL ( g_object_new ( VIK_GOTO_XML_TOOL_TYPE, "label", "OSM Name finder",
-    "url-format", "http://gazetteer.openstreetmap.org/namefinder/search.xml?find=%s&max=1",
-    "lat-path", "/searchresults/named",
-    "lat-attr", "lat",
-    "lon-path", "/searchresults/named",
-    "lon-attr", "lon",
-    NULL ) );
-    vik_goto_register ( VIK_GOTO_TOOL ( namefinder ) );
-    g_object_unref ( namefinder );
 
   // Not really OSM but can't be bothered to create somewhere else to put it...
   webtool = vik_webtool_center_new_with_members ( _("Wikimedia Toolserver GeoHack"), "http://tools.wmflabs.org/geohack/geohack.php?params=%s;%s" );

--- a/src/vikgoto.c
+++ b/src/vikgoto.c
@@ -49,6 +49,23 @@ static GList *goto_tools_list = NULL;
 #define VIK_SETTINGS_GOTO_PROVIDER "goto_provider"
 int last_goto_tool = -1;
 
+struct VikGotoSearchWinData {
+  VikWindow *vw;
+  VikViewport * vvp;
+  GtkWidget *dialog;
+  GtkEntry *goto_entry;
+  GtkWidget *tool_list;
+  GtkWidget *scroll_view;
+  GtkTreeView *results_view;
+};
+
+static enum {
+  VIK_GOTO_SEARCH_DESC_COL = 0,
+  VIK_GOTO_SEARCH_LAT_COL,
+  VIK_GOTO_SEARCH_LON_COL,
+  VIK_GOTO_SEARCH_NUM_COLS
+};
+
 void vik_goto_register ( VikGotoTool *tool )
 {
   if ( IS_VIK_GOTO_TOOL( tool ) )
@@ -83,26 +100,6 @@ static void display_no_tool(VikWindow *vw)
   gtk_dialog_run ( GTK_DIALOG(dialog) );
 
   gtk_widget_destroy(dialog);
-}
-
-static gboolean prompt_try_again(VikWindow *vw, const gchar *msg)
-{
-  GtkWidget *dialog = NULL;
-  gboolean ret = TRUE;
-
-  dialog = gtk_dialog_new_with_buttons ( "", GTK_WINDOW(vw), 0, GTK_STOCK_OK, GTK_RESPONSE_ACCEPT, GTK_STOCK_CANCEL, GTK_RESPONSE_REJECT, NULL );
-  gtk_window_set_title(GTK_WINDOW(dialog), _("goto"));
-
-  GtkWidget *goto_label = gtk_label_new(msg);
-  gtk_box_pack_start ( GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), goto_label, FALSE, FALSE, 5 );
-  gtk_dialog_set_default_response ( GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT );
-  gtk_widget_show_all(dialog);
-
-  if ( gtk_dialog_run ( GTK_DIALOG(dialog) ) != GTK_RESPONSE_ACCEPT )
-    ret = FALSE;
-
-  gtk_widget_destroy(dialog);
-  return ret;
 }
 
 static gint find_entry = -1;
@@ -151,72 +148,6 @@ text_changed_cb (GtkEntry   *entry,
   gtk_widget_set_sensitive ( button, has_text );
 }
 
-static gchar *a_prompt_for_goto_string(VikWindow *vw)
-{
-  GtkWidget *dialog = NULL;
-
-  dialog = gtk_dialog_new_with_buttons ( "", GTK_WINDOW(vw), 0, GTK_STOCK_OK, GTK_RESPONSE_ACCEPT, GTK_STOCK_CANCEL, GTK_RESPONSE_REJECT, NULL );
-  gtk_window_set_title(GTK_WINDOW(dialog), _("goto"));
-
-  GtkWidget *tool_label = gtk_label_new(_("goto provider:"));
-  GtkWidget *tool_list = vik_combo_box_text_new ();
-  GList *current = g_list_first (goto_tools_list);
-  while (current != NULL)
-  {
-    char *label = NULL;
-    VikGotoTool *tool = current->data;
-    label = vik_goto_tool_get_label (tool);
-    vik_combo_box_text_append ( tool_list, label );
-    current = g_list_next (current);
-  }
-
-  get_provider ();
-  gtk_combo_box_set_active ( GTK_COMBO_BOX( tool_list ), last_goto_tool );
-
-  GtkWidget *goto_label = gtk_label_new(_("Enter address or place name:"));
-  GtkWidget *goto_entry = ui_entry_new ( last_goto_str, GTK_ENTRY_ICON_SECONDARY );
-
-  // 'ok' when press return in the entry
-  g_signal_connect_swapped (goto_entry, "activate", G_CALLBACK(a_dialog_response_accept), dialog);
-
-#if GTK_CHECK_VERSION (2,20,0)
-  GtkWidget *ok_button = gtk_dialog_get_widget_for_response ( GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT );
-  text_changed_cb ( GTK_ENTRY(goto_entry), NULL, ok_button );
-  g_signal_connect ( goto_entry, "notify::text", G_CALLBACK (text_changed_cb), ok_button );
-#endif
-  gtk_box_pack_start ( GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), tool_label, FALSE, FALSE, 5 );
-  gtk_box_pack_start ( GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), tool_list, FALSE, FALSE, 5 );
-  gtk_box_pack_start ( GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), goto_label, FALSE, FALSE, 5 );
-  gtk_box_pack_start ( GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), goto_entry, FALSE, FALSE, 5 );
-  gtk_dialog_set_default_response ( GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT );
-  gtk_widget_show_all(dialog);
-
-  // Ensure the text field has focus so we can start typing straight away
-  gtk_widget_grab_focus ( goto_entry );
-
-  if ( gtk_dialog_run ( GTK_DIALOG(dialog) ) != GTK_RESPONSE_ACCEPT ) {
-    gtk_widget_destroy(dialog);
-    return NULL;
-  }
-  
-  // TODO check if list is empty
-  last_goto_tool = gtk_combo_box_get_active ( GTK_COMBO_BOX(tool_list) );
-  gchar *provider = vik_goto_tool_get_label ( g_list_nth_data (goto_tools_list, last_goto_tool) );
-  a_settings_set_string ( VIK_SETTINGS_GOTO_PROVIDER, provider );
-
-  gchar *goto_str = g_strdup ( gtk_entry_get_text ( GTK_ENTRY(goto_entry) ) );
-
-  gtk_widget_destroy(dialog);
-
-  if (goto_str[0] != '\0') {
-    if (last_goto_str)
-      g_free(last_goto_str);
-    last_goto_str = g_strdup(goto_str);
-  }
-
-  return(goto_str);   /* goto_str needs to be freed by caller */
-}
-
 /**
  * Goto a place when we already have a string to search on
  *
@@ -237,46 +168,219 @@ static gboolean vik_goto_place ( VikWindow *vw, VikViewport *vvp, gchar* name, V
   return FALSE;
 }
 
-void a_vik_goto(VikWindow *vw, VikViewport *vvp)
+static gboolean vik_goto_search_list_select ( GtkTreeSelection *sel, GtkTreeModel *model, GtkTreePath *path, gboolean path_currently_selected, gpointer pdata )
 {
-  VikCoord new_center;
-  gchar *s_str;
-  gboolean more = TRUE;
+  struct VikGotoSearchWinData *data = (struct VikGotoSearchWinData *) pdata;
+  GtkTreeIter iter;
 
-  if (goto_tools_list == NULL)
+  if ( path_currently_selected )
+    return TRUE;
+
+  if ( gtk_tree_model_get_iter ( model, &iter, path ) )
+  {
+    gdouble lat;
+    gdouble lon;
+
+    gtk_tree_model_get ( model, &iter, VIK_GOTO_SEARCH_LAT_COL, &lat, -1 );
+    gtk_tree_model_get ( model, &iter, VIK_GOTO_SEARCH_LON_COL, &lon, -1 );
+
+    if ( last_coord )
+      g_free ( last_coord );
+    last_coord = g_malloc( sizeof(VikCoord) );
+
+    struct LatLon ll = { lat, lon };
+    vik_coord_load_from_latlon ( last_coord, VIK_COORD_LATLON, &ll );
+
+    if ( last_successful_goto_str )
+      g_free ( last_successful_goto_str );
+    last_successful_goto_str = g_strdup ( last_goto_str );
+
+    vik_viewport_set_center_coord( data->vvp, last_coord, TRUE );
+    vik_layers_panel_emit_update ( vik_window_layers_panel(data->vw) );
+  }
+
+  return TRUE;
+}
+
+static void vik_goto_search_response ( struct VikGotoSearchWinData *data, gint response )
+{
+  if ( response == GTK_RESPONSE_ACCEPT )
+  {
+    // TODO check if list is empty
+    last_goto_tool = gtk_combo_box_get_active ( GTK_COMBO_BOX(data->tool_list) );
+    gchar *provider = vik_goto_tool_get_label ( g_list_nth_data (goto_tools_list, last_goto_tool) );
+    a_settings_set_string ( VIK_SETTINGS_GOTO_PROVIDER, provider );
+
+    gchar *goto_str = g_strdup ( gtk_entry_get_text ( GTK_ENTRY(data->goto_entry) ) );
+
+    if (goto_str[0] != '\0') {
+      if ( last_goto_str )
+        g_free ( last_goto_str );
+      last_goto_str = g_strdup ( goto_str );
+    }
+
+    VikGotoTool *tool = g_list_nth_data ( goto_tools_list, last_goto_tool );
+
+    GList *candidates = NULL;
+
+    vik_window_set_busy_cursor_widget ( data->dialog, data->vw );
+    int ans = vik_goto_tool_get_candidates ( tool, data->vw, data->vvp, goto_str, &candidates );
+    vik_window_clear_busy_cursor_widget ( data->dialog, data->vw );
+
+    if ( ans == 0 ) {
+      // make results visible
+      gtk_widget_set_size_request( GTK_WIDGET(data->scroll_view), 320, 240 );
+      gtk_widget_set_size_request( GTK_WIDGET(data->results_view), 320, 240 );
+      gtk_widget_show ( data->scroll_view );
+
+      GtkListStore *results_store = gtk_list_store_new ( VIK_GOTO_SEARCH_NUM_COLS,
+                                                         G_TYPE_STRING,
+                                                         G_TYPE_DOUBLE,
+                                                         G_TYPE_DOUBLE );
+      GtkTreeIter results_iter;
+
+      for ( GList *l = candidates; l != NULL; l = l->next )
+      {
+        struct VikGotoCandidate *cand = (struct VikGotoCandidate *) l->data;
+        gtk_list_store_append ( results_store, &results_iter );
+        gtk_list_store_set ( results_store, &results_iter,
+                             VIK_GOTO_SEARCH_DESC_COL, cand->description,//cand->description,
+                             VIK_GOTO_SEARCH_LAT_COL, cand->ll.lat,
+                             VIK_GOTO_SEARCH_LON_COL, cand->ll.lon,
+                             -1 );
+      }
+
+      gtk_tree_view_set_model ( data->results_view, GTK_TREE_MODEL(results_store) );
+
+      if ( g_list_length( candidates ) > 0 )
+      {
+        GtkTreeIter first_iter;
+        gtk_tree_model_get_iter_first ( GTK_TREE_MODEL(results_store), &first_iter);
+        GtkTreeSelection *selection = gtk_tree_view_get_selection( data->results_view );
+        gtk_tree_selection_select_iter ( selection, &first_iter );
+      }
+
+      g_object_unref ( results_store );
+      g_free ( goto_str );
+      g_list_free_full ( candidates, vik_goto_tool_free_candidate );
+    }
+    else
+    {
+      a_dialog_error_msg ( GTK_WINDOW(data->vw), "Service request failure." );
+    }
+  }
+  else if ( response == GTK_RESPONSE_CLOSE )
+  {
+    gtk_widget_destroy ( data->dialog );
+    g_free( data );
+  }
+}
+
+void a_vik_goto ( VikWindow *vw, VikViewport *vvp )
+{
+  GtkWidget *dialog = NULL;
+
+  if ( goto_tools_list == NULL )
   {
     /* Empty list */
-    display_no_tool(vw);
+    display_no_tool ( vw );
     return;
   }
 
-  do {
-    s_str = a_prompt_for_goto_string(vw);
-    if ((!s_str) || (s_str[0] == 0)) {
-      more = FALSE;
-    }
-    else {
-      int ans = vik_goto_tool_get_coord(g_list_nth_data (goto_tools_list, last_goto_tool), vw, vvp, s_str, &new_center);
-      if ( ans == 0 ) {
-        if (last_coord)
-          g_free(last_coord);
-        last_coord = g_malloc(sizeof(VikCoord));
-        *last_coord = new_center;
-        if (last_successful_goto_str)
-          g_free(last_successful_goto_str);
-        last_successful_goto_str = g_strdup(last_goto_str);
-        vik_viewport_set_center_coord(vvp, &new_center, TRUE);
-        more = FALSE;
-      }
-      else if ( ans == -1 ) {
-        if (!prompt_try_again(vw, _("I don't know that place. Do you want another goto?")))
-          more = FALSE;
-      }
-      else if (!prompt_try_again(vw, _("Service request failure. Do you want another goto?")))
-        more = FALSE;
-    }
-    g_free(s_str);
-  } while (more);
+  dialog = gtk_dialog_new_with_buttons ( "", GTK_WINDOW(vw), 0, 
+                                         GTK_STOCK_FIND, GTK_RESPONSE_ACCEPT,
+                                         GTK_STOCK_CLOSE, GTK_RESPONSE_CLOSE,
+                                         NULL );
+  gtk_window_set_transient_for ( GTK_WINDOW(dialog), GTK_WINDOW(vw) );
+  gtk_window_set_title( GTK_WINDOW(dialog), _("goto") );
+
+  GtkWidget *tool_label = gtk_label_new( _("goto provider:") );
+  GtkWidget *tool_list = vik_combo_box_text_new ();
+  GList *current = g_list_first ( goto_tools_list );
+  while ( current != NULL )
+  {
+    char *label = NULL;
+    VikGotoTool *tool = current->data;
+    label = vik_goto_tool_get_label ( tool );
+    vik_combo_box_text_append ( tool_list, label );
+    current = g_list_next ( current );
+  }
+
+  get_provider ();
+  gtk_combo_box_set_active ( GTK_COMBO_BOX( tool_list ), last_goto_tool );
+
+  GtkWidget *goto_label = gtk_label_new(_("Enter address or place name:"));
+  GtkWidget *goto_entry = ui_entry_new ( last_goto_str, GTK_ENTRY_ICON_SECONDARY );
+
+  // 'ok' when press return in the entry
+  g_signal_connect_swapped ( goto_entry, "activate", G_CALLBACK(a_dialog_response_accept), dialog );
+
+#if GTK_CHECK_VERSION (2,20,0)
+  GtkWidget *search_button = gtk_dialog_get_widget_for_response ( GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT );
+  text_changed_cb ( GTK_ENTRY(goto_entry), NULL, search_button );
+  g_signal_connect ( goto_entry, "notify::text", G_CALLBACK(text_changed_cb), search_button );
+#endif
+
+  GtkWidget *results_view = gtk_tree_view_new ();
+  GtkWidget *scroll_view = gtk_scrolled_window_new ( NULL, NULL );
+
+  gtk_widget_set_size_request( GTK_WIDGET(scroll_view), 0, 0 );
+
+  gtk_container_add ( GTK_CONTAINER(scroll_view), results_view );
+  gtk_scrolled_window_set_policy ( GTK_SCROLLED_WINDOW(scroll_view), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC );
+  
+  GtkCellRenderer *desc_renderer = gtk_cell_renderer_text_new ();
+  gtk_tree_view_insert_column_with_attributes ( GTK_TREE_VIEW(results_view),
+                                                -1,
+                                                "Description",
+                                                desc_renderer,
+                                                "text", VIK_GOTO_SEARCH_DESC_COL,
+                                                NULL );
+
+  GtkTreeViewColumn *lat_col;
+  lat_col = gtk_tree_view_column_new_with_attributes ( "Latitude",
+                                                       gtk_cell_renderer_text_new (),
+                                                       "text", VIK_GOTO_SEARCH_LAT_COL,
+                                                       NULL );
+  gtk_tree_view_column_set_visible ( lat_col, FALSE );
+  gtk_tree_view_append_column ( GTK_TREE_VIEW(results_view), lat_col );
+
+  GtkTreeViewColumn *lon_col;
+  lon_col = gtk_tree_view_column_new_with_attributes ( "Longitude",
+                                                       gtk_cell_renderer_text_new (),
+                                                       "text", VIK_GOTO_SEARCH_LON_COL,
+                                                       NULL );
+  gtk_tree_view_column_set_visible ( lon_col, FALSE );
+  gtk_tree_view_append_column ( GTK_TREE_VIEW(results_view), lon_col );
+
+  struct VikGotoSearchWinData *win_data = g_malloc ( sizeof(struct VikGotoSearchWinData) );
+  win_data->vw = vw;
+  win_data->vvp = vvp;
+  win_data->dialog = dialog;
+  win_data->goto_entry = GTK_ENTRY(goto_entry);
+  win_data->scroll_view = scroll_view;
+  win_data->results_view = GTK_TREE_VIEW(results_view);
+  win_data->tool_list = tool_list;
+
+  GtkTreeSelection *selection = gtk_tree_view_get_selection ( GTK_TREE_VIEW(results_view) );
+  gtk_tree_selection_set_select_function ( selection, vik_goto_search_list_select, win_data, NULL );
+
+  gtk_box_pack_start ( GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), tool_label, FALSE, FALSE, 5 );
+  gtk_box_pack_start ( GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), tool_list, FALSE, FALSE, 5 );
+  gtk_box_pack_start ( GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), goto_label, FALSE, FALSE, 5 );
+  gtk_box_pack_start ( GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), goto_entry, FALSE, FALSE, 5 );
+  gtk_box_pack_start ( GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), scroll_view, TRUE, TRUE, 5 );
+  gtk_dialog_set_default_response ( GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT );
+  g_signal_connect_swapped ( GTK_DIALOG(dialog), "response", G_CALLBACK(vik_goto_search_response), win_data );
+
+  gtk_widget_show_all ( dialog );
+  // don't show the scroll view until we have something to show
+  gtk_widget_hide ( scroll_view );
+
+  // Ensure the text field has focus so we can start typing straight away
+  gtk_widget_grab_focus ( goto_entry );
+
+  gtk_widget_show ( dialog );
 }
 
 #define JSON_LATITUDE_PATTERN "\"geoplugin_latitude\":\""

--- a/src/vikgoto.c
+++ b/src/vikgoto.c
@@ -59,7 +59,7 @@ struct VikGotoSearchWinData {
   GtkTreeView *results_view;
 };
 
-static enum {
+enum {
   VIK_GOTO_SEARCH_DESC_COL = 0,
   VIK_GOTO_SEARCH_LAT_COL,
   VIK_GOTO_SEARCH_LON_COL,

--- a/src/vikgototool.c
+++ b/src/vikgototool.c
@@ -204,6 +204,11 @@ gboolean vik_goto_tool_parse_file_for_latlon (VikGotoTool *self, gchar *filename
   return VIK_GOTO_TOOL_GET_CLASS( self )->parse_file_for_latlon( self, filename, ll );
 }
 
+gboolean vik_goto_tool_parse_file_for_candidates (VikGotoTool *self, gchar *filename, GList **candidates)
+{
+  return VIK_GOTO_TOOL_GET_CLASS( self )->parse_file_for_candidates( self, filename, candidates );
+}
+
 /**
  * vik_goto_tool_get_coord:
  *
@@ -226,11 +231,7 @@ int vik_goto_tool_get_coord ( VikGotoTool *self, VikWindow *vw, VikViewport *vvp
   int ret = 0;  /* OK */
   struct LatLon ll;
 
-  g_debug("%s: raw goto: %s", __FUNCTION__, srch_str);
-
   escaped_srch_str = g_uri_escape_string(srch_str, NULL, TRUE);
-
-  g_debug("%s: escaped goto: %s", __FUNCTION__, escaped_srch_str);
 
   uri = g_strdup_printf(vik_goto_tool_get_url_format(self), escaped_srch_str);
 
@@ -242,7 +243,6 @@ int vik_goto_tool_get_coord ( VikGotoTool *self, VikWindow *vw, VikViewport *vvp
     goto done_no_file;
   }
 
-  g_debug("%s: %s", __FILE__, tmpname);
   if (!vik_goto_tool_parse_file_for_latlon(self, tmpname, &ll)) {
     ret = -1;
     goto done;
@@ -256,4 +256,63 @@ done_no_file:
   g_free(escaped_srch_str);
   g_free(uri);
   return ret;
+}
+
+/**
+ * vik_goto_tool_get_candidates
+ *
+ * @self:       The #VikGotoTool
+ * @vvp:        The #VikViewport
+ * @srch_str:   The string to search with
+ * @candidates: Returns a list of matches
+ *
+ * Returns: An integer value indicating:
+ *  0  = search found something
+ *  -1 = search place not found by the #VikGotoTool
+ *  1  = search unavailable in the #VikGotoTool due to communication issue
+ *
+ */
+int vik_goto_tool_get_candidates ( VikGotoTool *self, VikWindow *vw, VikViewport *vvp, gchar *srch_str, GList **candidates )
+{
+  gchar *tmpname;
+  gchar *uri;
+  gchar *escaped_srch_str;
+  int ret = 0;  /* OK */
+
+  escaped_srch_str = g_uri_escape_string(srch_str, NULL, TRUE);
+
+  uri = g_strdup_printf(vik_goto_tool_get_url_format(self), escaped_srch_str);
+
+  tmpname = a_download_uri_to_tmp_file ( uri, vik_goto_tool_get_download_options(self) );
+
+  if ( !tmpname ) {
+    // Some kind of download error, so no tmp file
+    ret = 1;
+    goto done_no_file;
+  }
+
+  g_debug("%s: %s", __FILE__, tmpname);
+  if (!vik_goto_tool_parse_file_for_candidates(self, tmpname, candidates)) {
+    ret = -1;
+    goto done;
+  }
+
+done:
+  (void)util_remove(tmpname);
+done_no_file:
+  g_free(tmpname);
+  g_free(escaped_srch_str);
+  g_free(uri);
+  return ret;
+}
+
+/**
+ * vik_goto_tool_free_candidates
+ *
+ * @candidate: The candidate object to free
+ */
+void vik_goto_tool_free_candidate ( struct VikGotoCandidate *candidate )
+{
+  g_free ( candidate->description );
+  g_free ( candidate );
 }

--- a/src/vikgototool.c
+++ b/src/vikgototool.c
@@ -309,10 +309,11 @@ done_no_file:
 /**
  * vik_goto_tool_free_candidates
  *
- * @candidate: The candidate object to free
+ * @data: The candidate object to free
  */
-void vik_goto_tool_free_candidate ( struct VikGotoCandidate *candidate )
+void vik_goto_tool_free_candidate ( gpointer data )
 {
+  struct VikGotoCandidate *candidate = data;
   g_free ( candidate->description );
   g_free ( candidate );
 }

--- a/src/vikgototool.h
+++ b/src/vikgototool.h
@@ -46,6 +46,7 @@ struct _VikGotoToolClass
   gchar *(* get_url_format) (VikGotoTool *self);
   DownloadFileOptions *(* get_download_options) (VikGotoTool *self);
   gboolean (* parse_file_for_latlon) (VikGotoTool *self, gchar *filename, struct LatLon *ll);
+  gboolean (* parse_file_for_candidates) (VikGotoTool *self, gchar *filename, GList *candidates);
 };
 
 GType vik_goto_tool_get_type ();
@@ -54,11 +55,18 @@ struct _VikGotoTool {
   GObject obj;
 };
 
+struct VikGotoCandidate {
+  gchar *description;
+  struct LatLon ll;
+};
+
 gchar *vik_goto_tool_get_label ( VikGotoTool *self );
 gchar *vik_goto_tool_get_url_format ( VikGotoTool *self );
 DownloadFileOptions *vik_goto_tool_get_download_options ( VikGotoTool *self );
 gboolean vik_goto_tool_parse_file_for_latlon ( VikGotoTool *self, gchar *filename, struct LatLon *ll );
 int vik_goto_tool_get_coord ( VikGotoTool *self, VikWindow *vw, VikViewport *vvp, gchar *srch_str, VikCoord *coord );
+int vik_goto_tool_get_candidates ( VikGotoTool *self, VikWindow *vw, VikViewport *vvp, gchar *srch_str, GList **candidates );
+void vik_goto_tool_free_candidate ( struct VikGotoCandidate *candidate );
 
 G_END_DECLS
 

--- a/src/vikgototool.h
+++ b/src/vikgototool.h
@@ -46,7 +46,7 @@ struct _VikGotoToolClass
   gchar *(* get_url_format) (VikGotoTool *self);
   DownloadFileOptions *(* get_download_options) (VikGotoTool *self);
   gboolean (* parse_file_for_latlon) (VikGotoTool *self, gchar *filename, struct LatLon *ll);
-  gboolean (* parse_file_for_candidates) (VikGotoTool *self, gchar *filename, GList *candidates);
+  gboolean (* parse_file_for_candidates) (VikGotoTool *self, gchar *filename, GList **candidates);
 };
 
 GType vik_goto_tool_get_type ();
@@ -66,7 +66,7 @@ DownloadFileOptions *vik_goto_tool_get_download_options ( VikGotoTool *self );
 gboolean vik_goto_tool_parse_file_for_latlon ( VikGotoTool *self, gchar *filename, struct LatLon *ll );
 int vik_goto_tool_get_coord ( VikGotoTool *self, VikWindow *vw, VikViewport *vvp, gchar *srch_str, VikCoord *coord );
 int vik_goto_tool_get_candidates ( VikGotoTool *self, VikWindow *vw, VikViewport *vvp, gchar *srch_str, GList **candidates );
-void vik_goto_tool_free_candidate ( struct VikGotoCandidate *candidate );
+void vik_goto_tool_free_candidate ( gpointer candidate );
 
 G_END_DECLS
 

--- a/src/vikwindow.c
+++ b/src/vikwindow.c
@@ -3329,6 +3329,18 @@ void vik_window_clear_busy_cursor ( VikWindow *vw )
   gdk_window_set_cursor ( gtk_widget_get_window(GTK_WIDGET(vw->viking_vvp)), vw->viewport_cursor );
 }
 
+void vik_window_set_busy_cursor_widget ( GtkWidget *widget, VikWindow *vw )
+{
+  gdk_window_set_cursor ( gtk_widget_get_window ( widget ), vw->busy_cursor );
+  vik_window_set_busy_cursor ( vw );
+}
+
+void vik_window_clear_busy_cursor_widget ( GtkWidget *widget, VikWindow *vw )
+{
+  gdk_window_set_cursor ( gtk_widget_get_window( widget ), NULL );
+  vik_window_clear_busy_cursor ( vw );
+}
+
 // ATM Call upon file load
 // TODO maybe also hook into (new) signals on new/deleted viklayers (of TRW)
 // THen only need for adds to mark additional entries.

--- a/src/vikwindow.h
+++ b/src/vikwindow.h
@@ -90,6 +90,8 @@ GThread *vik_window_get_thread ( VikWindow *vw );
 
 void vik_window_set_busy_cursor ( VikWindow *vw );
 void vik_window_clear_busy_cursor ( VikWindow *vw );
+void vik_window_set_busy_cursor_widget ( GtkWidget *widget, VikWindow *vw );
+void vik_window_clear_busy_cursor_widget ( GtkWidget *widget, VikWindow *vw );
 
 typedef struct {
   VikWindow *vw;


### PR DESCRIPTION
The search dialog is initially similar, but when a search is done, a
list of results is displayed instead of just the first hit visited.

Implemented for Nominatum and Geonames.  Name finder has been removed
because the server has not been available since 2010.  The currently
disabled Google code has been extended only enough to compile, with a
todo left for the candidate parsing code (there is no point in
implementing this for a discontinued API).