### PR TITLE
Move search dialog to a side pane

### DIFF
--- a/help/viking.xml.in
+++ b/help/viking.xml.in
@@ -453,7 +453,7 @@ and docbook-xsl in your Build-Depends control field.
           <variablelist>
             <varlistentry>
               <term>label</term>
-              <listitem><para>the text displayed in the <guilabel>Go-To</guilabel> dialog</para></listitem>
+              <listitem><para>the text displayed in the <guilabel>Go-To</guilabel> pane</para></listitem>
             </varlistentry>
             <varlistentry>
               <term>url-format</term>


### PR DESCRIPTION
Ctrl-f will show it, and ctrl-f while shown will refocus text entry.

Escape in text entry or list view of results will close. Also close
button provided.

I've done this with minimal changes to the code. I.e. vikgoto.c takes care of adding the find box to the side panel. Perhaps this is not ideal?