### PR TITLE
Make double click on select tool change zoom

### DIFF
--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -2460,7 +2460,7 @@ If <keycap>Ctrl</keycap> or <keycap>Shift</keycap> is held down at the same time
 Note that whole tracks cannot be moved.
 </para>
 <para>
-Double clicking the left mouse button will center the map at that point.
+Double clicking the left (or right) mouse button will center the map at that point and zoom in (or out).
 </para>
 <para>
 This mode can also be entered by the keyboard shortcut <keycap>Ctrl+Shift+S</keycap>


### PR DESCRIPTION
The recent changes to Viking are nice. I especially like the "Tracks Area Coverage".

Making the select tool act like pan when no track point was clicked is good. I found it frustrating that i could not also change the zoom level. I've made changes to that double-click with the select tool either zooms in or out depending on which button was clicked.