### PR TITLE
Add great circle rendering to the ruler tool

### DIFF
--- a/src/vikcoord.c
+++ b/src/vikcoord.c
@@ -225,3 +225,81 @@ gdouble vik_coord_angle (const VikCoord *vc1, const VikCoord *vc2)
   angle = fmod (RAD2DEG(angle) + 360.0, 360);
   return angle;
 }
+
+/**
+ * vik_coord_angle_end:
+ *
+ * Get angle of first coord from the second one in degrees (final bearing). Basically the inverse of vik_coord_angle.
+ *
+ */
+gdouble vik_coord_angle_end (const VikCoord *vc1, const VikCoord *vc2)
+{
+  struct LatLon ll1, ll2;
+  vik_coord_to_latlon ( vc1, &ll1 );
+  vik_coord_to_latlon ( vc2, &ll2 );
+
+  // Convert to radians for use in the algorithm
+  gdouble rlat1 = DEG2RAD(ll1.lat);
+  gdouble rlong1 = DEG2RAD(ll1.lon);
+  gdouble rlat2 = DEG2RAD(ll2.lat);
+  gdouble rlong2 = DEG2RAD(ll2.lon);
+
+  // This formula is for the final bearing
+  //θ = atan2( sin Δλ ⋅ cos φ2 , cos φ1 ⋅ sin φ2 − sin φ1 ⋅ cos φ2 ⋅ cos Δλ )
+  // in -pi to +pi radians
+  gdouble dLon = (rlong2 - rlong1);
+  gdouble y = sin(dLon) * cos(rlat1);
+  gdouble x = (-cos(rlat2) * sin(rlat1)) + (sin(rlat2) * cos(rlat1) * cos(dLon));
+  gdouble angle = atan2(y, x);
+
+  // Bring into range 0..360 degrees
+  angle = fmod (RAD2DEG(angle) + 360.0, 360);
+  return angle;
+}
+
+/**
+ * vik_coord_geodesic_waypoint:
+ *
+ * Calculate the waypoint at angular distance ratio n between vc1 and vc2. n = 0 returns vc1, n = 1 returns vc2.
+ * Used for drawing great circles for the ruler tool.
+ * For the relevant formulas, refer to https://en.wikipedia.org/wiki/Great-circle_navigation
+ *
+ */
+void vik_coord_geodesic_waypoint (const VikCoord *vc1, const VikCoord *vc2, gdouble n, VikCoord *wpt)
+{
+  struct LatLon ll, ll1, ll2;
+  vik_coord_to_latlon ( vc1, &ll1 );
+  vik_coord_to_latlon ( vc2, &ll2 );
+
+  gdouble rlat1 = DEG2RAD(ll1.lat);
+  gdouble rlong1 = DEG2RAD(ll1.lon);
+  gdouble rlat2 = DEG2RAD(ll2.lat);
+  gdouble rlong2 = DEG2RAD(ll2.lon);
+  gdouble dLon = rlong2 - rlong1;
+
+  gdouble bearing1 = DEG2RAD(vik_coord_angle ( vc1, vc2 ));
+
+
+  gdouble bearing0 = atan2(sin(bearing1) * cos(rlat1), sqrt(pow(cos(bearing1), 2) + pow(sin(bearing1)*sin(rlat1), 2)));
+
+  gdouble sigma_01 = atan2(tan(rlat1), cos(bearing1));
+  gdouble sigma_12 = atan2(sqrt(pow(cos(rlat1)*sin(rlat2) - sin(rlat1)*cos(rlat2)*cos(dLon), 2) + pow(cos(rlat2)*sin(dLon), 2)),
+                           sin(rlat1)*sin(rlat2) + cos(rlat1)*cos(rlat2)*cos(dLon));
+
+  gdouble sigma = sigma_01 + n * sigma_12;
+  gdouble rlong0 = rlong1 - atan2(sin(bearing0)*sin(sigma_01), cos(sigma_01));
+
+  ll.lat = atan(cos(bearing0)*sin(sigma) / (sqrt(pow(cos(sigma), 2) + pow(sin(bearing0)*sin(sigma), 2))));
+  ll.lon = rlong0 + atan2(sin(bearing0)*sin(sigma), cos(sigma));
+
+  ll.lon = fmod(ll.lon + 2*M_PI, 2*M_PI);
+  if (ll.lon > M_PI) {
+    ll.lon -= 2*M_PI;
+  }
+
+  VikCoord coord;
+  coord.north_south = RAD2DEG(ll.lat);
+  coord.east_west = RAD2DEG(ll.lon);
+  coord.mode = VIK_COORD_LATLON;
+  vik_coord_copy_convert ( &coord, vc1->mode, wpt );
+}

--- a/src/vikcoord.c
+++ b/src/vikcoord.c
@@ -258,14 +258,14 @@ gdouble vik_coord_angle_end (const VikCoord *vc1, const VikCoord *vc2)
 }
 
 /**
- * vik_coord_geodesic_waypoint:
+ * vik_coord_geodesic_coord:
  *
- * Calculate the waypoint at angular distance ratio n between vc1 and vc2. n = 0 returns vc1, n = 1 returns vc2.
+ * Calculate the geodesic coordinate at angular distance ratio n between vc1 and vc2. n = 0 returns vc1, n = 1 returns vc2.
  * Used for drawing great circles for the ruler tool.
  * For the relevant formulas, refer to https://en.wikipedia.org/wiki/Great-circle_navigation
  *
  */
-void vik_coord_geodesic_waypoint (const VikCoord *vc1, const VikCoord *vc2, gdouble n, VikCoord *wpt)
+void vik_coord_geodesic_coord (const VikCoord *vc1, const VikCoord *vc2, gdouble n, VikCoord *rvc)
 {
   struct LatLon ll, ll1, ll2;
   vik_coord_to_latlon ( vc1, &ll1 );
@@ -301,5 +301,5 @@ void vik_coord_geodesic_waypoint (const VikCoord *vc1, const VikCoord *vc2, gdou
   coord.north_south = RAD2DEG(ll.lat);
   coord.east_west = RAD2DEG(ll.lon);
   coord.mode = VIK_COORD_LATLON;
-  vik_coord_copy_convert ( &coord, vc1->mode, wpt );
+  vik_coord_copy_convert ( &coord, vc1->mode, rvc );
 }

--- a/src/vikcoord.h
+++ b/src/vikcoord.h
@@ -64,7 +64,7 @@ gboolean vik_coord_inside(const VikCoord *coord, const VikCoord *tl, const VikCo
 gdouble vik_coord_angle(const VikCoord *vc1, const VikCoord *vc2);
 gdouble vik_coord_angle_end(const VikCoord *vc1, const VikCoord *vc2);
 
-void vik_coord_geodesic_waypoint(const VikCoord *vc1, const VikCoord *vc2, gdouble n, VikCoord *wpt);
+void vik_coord_geodesic_coord(const VikCoord *vc1, const VikCoord *vc2, gdouble n, VikCoord *wpt);
 
 G_END_DECLS
 

--- a/src/vikcoord.h
+++ b/src/vikcoord.h
@@ -61,7 +61,10 @@ void vik_coord_set_area(const VikCoord *coord, const struct LatLon *wh, VikCoord
 gboolean vik_coord_inside(const VikCoord *coord, const VikCoord *tl, const VikCoord *br);
 /* all coord operations MUST BE ABSTRACTED!!! */
 
-gdouble vik_coord_angle (const VikCoord *vc1, const VikCoord *vc2);
+gdouble vik_coord_angle(const VikCoord *vc1, const VikCoord *vc2);
+gdouble vik_coord_angle_end(const VikCoord *vc1, const VikCoord *vc2);
+
+void vik_coord_geodesic_waypoint(const VikCoord *vc1, const VikCoord *vc2, gdouble n, VikCoord *wpt);
 
 G_END_DECLS
 

--- a/src/vikwindow.c
+++ b/src/vikwindow.c
@@ -1803,9 +1803,10 @@ static void draw_ruler(VikViewport *vvp, GdkDrawable *d, GdkGC *gc, const VikCoo
     gint x, y;
 
     /* draw geodesic */
-    for (gdouble step=0;step<=1;step+=0.01) {
+    for (gint step=0;step<=100;step++) {
+      gdouble n = (gdouble) step / 100;
       VikCoord coord;
-      vik_coord_geodesic_coord ( start, end, step, &coord );
+      vik_coord_geodesic_coord ( start, end, n, &coord );
       vik_viewport_coord_to_screen ( vvp, &coord, &x, &y );
 
       struct LatLon ll;

--- a/src/vikwindow.c
+++ b/src/vikwindow.c
@@ -1743,49 +1743,100 @@ static gboolean draw_scroll (VikWindow *vw, GdkEventScroll *event)
   return TRUE;
 }
 
-
-
 /********************************************************************************
  ** Ruler tool code
  ********************************************************************************/
-static void draw_ruler(VikViewport *vvp, GdkDrawable *d, GdkGC *gc, gint x1, gint y1, gint x2, gint y2, gdouble distance)
+static void draw_ruler(VikViewport *vvp, GdkDrawable *d, GdkGC *gc, const VikCoord *start, VikCoord *end)
 {
   PangoLayout *pl;
   gchar str[128];
   GdkGC *labgc = vik_viewport_new_gc ( vvp, "#cccccc", 1);
   GdkGC *thickgc = gdk_gc_new(d);
-  
-  gdouble len = sqrt((x1-x2)*(x1-x2) + (y1-y2)*(y1-y2));
-  gdouble dx = (x2-x1)/len*10; 
-  gdouble dy = (y2-y1)/len*10;
-  gdouble c = cos(DEG2RAD(15.0));
-  gdouble s = sin(DEG2RAD(15.0));
-  gdouble angle;
-  gdouble baseangle = 0;
+
+  gint x1, y1, x2, y2;
+  vik_viewport_coord_to_screen ( vvp, start, &x1, &y1 );
+
+  /* normalize end position in case the mouse pointer was moved out of the map */
+  if (end->mode == VIK_COORD_LATLON) {
+    end->east_west = fmod(end->east_west + 360, 360);
+    if (end->east_west > 180) {
+      end->east_west -= 360;
+    }
+  }
+  vik_viewport_coord_to_screen ( vvp, end, &x2, &y2 );
+
+
+  gdouble len, dx, dy, c, s, angle, angle_end, display_angle, baseangle;
   gint i;
 
-  /* draw line with arrow ends */
-  {
-    gint tmp_x1=x1, tmp_y1=y1, tmp_x2=x2, tmp_y2=y2;
-    a_viewport_clip_line(&tmp_x1, &tmp_y1, &tmp_x2, &tmp_y2);
-    gdk_draw_line(d, gc, tmp_x1, tmp_y1, tmp_x2, tmp_y2);
+  vik_viewport_compute_bearing ( vvp, x1, y1, x2, y2, &display_angle, &baseangle );
+  angle = fmod(baseangle  + DEG2RAD(vik_coord_angle ( start, end )), 2*M_PI);
+  angle_end = fmod(baseangle + DEG2RAD(vik_coord_angle_end ( start, end )), 2*M_PI);
+
+  gdouble distance = vik_coord_diff (start, end);
+
+  len = sqrt((x1-x2)*(x1-x2) + (y1-y2)*(y1-y2));
+  dx = (x2-x1)/len*10;
+  dy = (y2-y1)/len*10;
+  c = cos(DEG2RAD(15.0));
+  s = sin(DEG2RAD(15.0));
+
+  /* if the distance is less than 10km, the curvature definetely won't be visible */
+  if (distance < 10e3) {
+    /* draw line with arrow ends */
+    a_viewport_clip_line(&x1, &y1, &x2, &y2);
+    gdk_draw_line(d, gc, x1, y1, x2, y2);
+
+    /* orthogonal bars */
+    gdk_draw_line(d, gc, x1 - dy, y1 + dx, x1 + dy, y1 - dx);
+    gdk_draw_line(d, gc, x2 - dy, y2 + dx, x2 + dy, y2 - dx);
+    /* arrow components */
+    gdk_draw_line(d, gc, x2, y2, x2 - (dx * c + dy * s), y2 - (dy * c - dx * s));
+    gdk_draw_line(d, gc, x2, y2, x2 - (dx * c - dy * s), y2 - (dy * c + dx * s));
+    gdk_draw_line(d, gc, x1, y1, x1 + (dx * c + dy * s), y1 + (dy * c - dx * s));
+    gdk_draw_line(d, gc, x1, y1, x1 + (dx * c - dy * s), y1 + (dy * c + dx * s));
   }
 
-  a_viewport_clip_line(&x1, &y1, &x2, &y2);
-  gdk_draw_line(d, gc, x1, y1, x2, y2);
+  else {
+    gint last_x = x1;
+    gint last_y = y1;
+    gint x, y;
 
-  gdk_draw_line(d, gc, x1 - dy, y1 + dx, x1 + dy, y1 - dx);
-  gdk_draw_line(d, gc, x2 - dy, y2 + dx, x2 + dy, y2 - dx);
-  gdk_draw_line(d, gc, x2, y2, x2 - (dx * c + dy * s), y2 - (dy * c - dx * s));
-  gdk_draw_line(d, gc, x2, y2, x2 - (dx * c - dy * s), y2 - (dy * c + dx * s));
-  gdk_draw_line(d, gc, x1, y1, x1 + (dx * c + dy * s), y1 + (dy * c - dx * s));
-  gdk_draw_line(d, gc, x1, y1, x1 + (dx * c - dy * s), y1 + (dy * c + dx * s));
+    /* draw geodesic */
+    for (gdouble step=0;step<=1;step+=0.001) {
+      VikCoord coord;
+      vik_coord_geodesic_waypoint ( start, end, step, &coord );
+      vik_viewport_coord_to_screen ( vvp, &coord, &x, &y );
+
+      struct LatLon ll;
+      vik_coord_to_latlon ( &coord, &ll) ;
+
+      if (sqrt(pow(last_x-x, 2) + pow(last_y-y, 2)) < 100) {;
+        gdk_draw_line(d, gc, last_x, last_y, x, y);
+      }
+      last_x = x;
+      last_y = y;
+    }
+
+    gdouble dx1 = 10 * cos(angle);
+    gdouble dy1 = 10 * sin(angle);
+    gdouble dx2 = 10 * cos(angle_end);
+    gdouble dy2 = 10 * sin(angle_end);
+
+    /* orthogonal bars */
+    gdk_draw_line(d, gc, x1 - dx1, y1 - dy1, x1 + dx1, y1 + dy1);
+    gdk_draw_line(d, gc, x2 - dx2, y2 - dy2, x2 + dx2, y2 + dy2);
+    /* arrow components */
+    gdk_draw_line(d, gc, x2, y2, x2 + (-dy2 * c + dx2 * s), y2 + (+dx2 * c + dy2 * s));
+    gdk_draw_line(d, gc, x2, y2, x2 + (-dy2 * c - dx2 * s), y2 + (+dx2 * c - dy2 * s));
+    gdk_draw_line(d, gc, x1, y1, x1 + (+dy1 * c + dx1 * s), y1 + (-dx1 * c + dy1 * s));
+    gdk_draw_line(d, gc, x1, y1, x1 + (+dy1 * c - dx1 * s), y1 + (-dx1 * c - dy1 * s));
+  }
+
 
   /* draw compass */
 #define CR 80
 #define CW 4
-
-  vik_viewport_compute_bearing ( vvp, x1, y1, x2, y2, &angle, &baseangle );
 
   {
     GdkColor color;
@@ -1868,14 +1919,19 @@ static void draw_ruler(VikViewport *vvp, GdkDrawable *d, GdkGC *gc, gint x1, gin
     }
 
     pango_layout_set_text(pl, str, -1);
-
     pango_layout_get_pixel_size ( pl, &wd, &hd );
+
+    gint mx, my;
+    VikCoord midpoint;
+    vik_coord_geodesic_waypoint ( start, end, 0.5, &midpoint );
+    vik_viewport_coord_to_screen ( vvp, &midpoint, &mx, &my );
+
     if (dy>0) {
-      xd = (x1+x2)/2 + dy;
-      yd = (y1+y2)/2 - hd/2 - dx;
+      xd = mx + dy;
+      yd = my - hd/2 - dx;
     } else {
-      xd = (x1+x2)/2 - dy;
-      yd = (y1+y2)/2 - hd/2 + dx;
+      xd = mx - dy;
+      yd = my - hd/2 + dx;
     }
 
     if ( xd < -5 || yd < -5 || xd > vik_viewport_get_width(vvp)+5 || yd > vik_viewport_get_height(vvp)+5 ) {
@@ -1990,7 +2046,7 @@ static void ruler_move_normal (VikLayer *vl, GdkEventMotion *event, tool_ed_t *s
   gchar *temp;
 
   if ( s->has_oldcoord ) {
-    int oldx, oldy, w1, h1, w2, h2;
+    int w1, h1, w2, h2;
     static GdkPixmap *buf = NULL;
     gchar *lat=NULL, *lon=NULL;
     w1 = vik_viewport_get_width(vvp); 
@@ -2006,10 +2062,9 @@ static void ruler_move_normal (VikLayer *vl, GdkEventMotion *event, tool_ed_t *s
 
     vik_viewport_screen_to_coord ( vvp, (gint) event->x, (gint) event->y, &coord );
     vik_coord_to_latlon ( &coord, &ll );
-    vik_viewport_coord_to_screen ( vvp, &s->oldcoord, &oldx, &oldy );
 
     gdk_draw_drawable (buf, vik_viewport_get_black_gc(vvp), vik_viewport_get_pixmap(vvp), 0, 0, 0, 0, -1, -1);
-    draw_ruler(vvp, buf, vik_viewport_get_black_gc(vvp), oldx, oldy, event->x, event->y, vik_coord_diff( &coord, &(s->oldcoord)) );
+    draw_ruler(vvp, buf, vik_viewport_get_black_gc(vvp), &s->oldcoord, &coord );
     if (draw_buf_done) {
       static gpointer pass_along[3];
       pass_along[0] = gtk_widget_get_window(GTK_WIDGET(vvp));

--- a/src/vikwindow.c
+++ b/src/vikwindow.c
@@ -1781,7 +1781,7 @@ static void draw_ruler(VikViewport *vvp, GdkDrawable *d, GdkGC *gc, const VikCoo
   c = cos(DEG2RAD(15.0));
   s = sin(DEG2RAD(15.0));
 
-  /* if the distance is less than 10km, the curvature definetely won't be visible */
+  /* if the distance is less than 10km, the curvature definitely won't be visible */
   if (distance < 10e3) {
     /* draw line with arrow ends */
     a_viewport_clip_line(&x1, &y1, &x2, &y2);
@@ -1803,9 +1803,9 @@ static void draw_ruler(VikViewport *vvp, GdkDrawable *d, GdkGC *gc, const VikCoo
     gint x, y;
 
     /* draw geodesic */
-    for (gdouble step=0;step<=1;step+=0.001) {
+    for (gdouble step=0;step<=1;step+=0.01) {
       VikCoord coord;
-      vik_coord_geodesic_waypoint ( start, end, step, &coord );
+      vik_coord_geodesic_coord ( start, end, step, &coord );
       vik_viewport_coord_to_screen ( vvp, &coord, &x, &y );
 
       struct LatLon ll;
@@ -1923,7 +1923,7 @@ static void draw_ruler(VikViewport *vvp, GdkDrawable *d, GdkGC *gc, const VikCoo
 
     gint mx, my;
     VikCoord midpoint;
-    vik_coord_geodesic_waypoint ( start, end, 0.5, &midpoint );
+    vik_coord_geodesic_coord ( start, end, 0.5, &midpoint );
     vik_viewport_coord_to_screen ( vvp, &midpoint, &mx, &my );
 
     if (dy>0) {


### PR DESCRIPTION
With this commit, the ruler tool now draws great circles instead of straight lines, which is visible when measuring large (>1000km) 
distances. Also, the initial bearing is calculated with the proper formula.

To do this, I changed the arguments of draw_ruler in vikwindow.c, partially rewrote it and added to new utility functions to vikcoord.c. (vik_coord_angle_end and vik_coord_geodesic_waypoints)

Also, sorry if I'm doing something wrong, this is the first time I'm contributing to a GitHub project.

Screenshot:
![Screenshot from 2020-09-03 16-01-53](https://user-images.githubusercontent.com/70705268/92126159-1f413800-ee00-11ea-88da-f5dbad7ec821.png)