### PR TITLE
Don't free provider name in search response

### DIFF
--- a/src/vikgoto.c
+++ b/src/vikgoto.c
@@ -193,7 +193,6 @@ static void vik_goto_search_response ( struct VikGotoSearchWinData *data, gint r
     last_goto_tool = gtk_combo_box_get_active ( GTK_COMBO_BOX(data->tool_list) );
     gchar *provider = vik_goto_tool_get_label ( g_list_nth_data (goto_tools_list, last_goto_tool) );
     a_settings_set_string ( VIK_SETTINGS_GOTO_PROVIDER, provider );
-    g_free ( provider );
 
     gchar *goto_str = g_strdup ( gtk_entry_get_text ( GTK_ENTRY(data->goto_entry) ) );
 


### PR DESCRIPTION
The string does not appear to be a copy that can be deleted. The
provider name is overwritten when the search dialog is next opened.