### PR TITLE
fix issue #123: autogen.sh fails because of missing `intltool` package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Git repository:
 
 On Debian Sid, following packages must be installed before building:
 
-	# sudo apt install gtk-doc-tools docbook-xsl yelp-tools libpng-dev libgtk-3-dev libicu-dev libjson-glib-dev
+	$ sudo apt install gtk-doc-tools docbook-xsl yelp-tools libpng-dev libgtk-3-dev libicu-dev libjson-glib-dev intltool
 
 The following packages are needed (they are included by default in Debian Sid, but not in other distributions). They must be installed too:
 


### PR DESCRIPTION
Hi,
I just add the missing package in the install section of `README.md`.
Cheers,
ben