### PR TITLE
Fix Brouter url

### DIFF
--- a/data/routing.xml
+++ b/data/routing.xml
@@ -20,6 +20,16 @@
     <property name="url-ll-lat-first">FALSE</property>
   </object>
   <object class="VikRoutingWebEngine">
+    <property name="id">brouterRiver</property>
+    <property name="label">brouter River</property>
+    <property name="format">gpx</property>
+    <property name="url-base">https://brouter.de/brouter?nogos=&amp;profile=river&amp;alternativeidx=0&amp;format=gpx</property>
+    <property name="url-start-ll">&amp;lonlats=%s,%s</property>
+    <property name="url-stop-ll">|%s,%s</property>
+    <property name="url-via-ll"></property>
+    <property name="url-ll-lat-first">FALSE</property>
+  </object>
+  <object class="VikRoutingWebEngine">
     <property name="id">osrmBicycle</property>
     <property name="label">OSRM Bicycle</property>
     <property name="format">viking-geojson-osrm</property>

--- a/data/routing.xml
+++ b/data/routing.xml
@@ -3,7 +3,7 @@
     <property name="id">brouter</property>
     <property name="label">brouter</property>
     <property name="format">gpx</property>
-    <property name="url-base">http://h2096617.stratoserver.net:443/brouter?nogos=&amp;profile=hiking-beta&amp;alternativeidx=0&amp;format=gpx</property>
+    <property name="url-base">https://brouter.de/brouter?nogos=&amp;profile=hiking-mountain&amp;alternativeidx=0&amp;format=gpx</property>
     <property name="url-start-ll">&amp;lonlats=%s,%s</property>
     <property name="url-stop-ll">|%s,%s</property>
     <property name="url-via-ll"></property>
@@ -13,7 +13,7 @@
     <property name="id">brouterCar</property>
     <property name="label">brouter Car</property>
     <property name="format">gpx</property>
-    <property name="url-base">http://h2096617.stratoserver.net:443/brouter?nogos=&amp;profile=car-fast&amp;alternativeidx=0&amp;format=gpx</property>
+    <property name="url-base">https://brouter.de/brouter?nogos=&amp;profile=car-fast&amp;alternativeidx=0&amp;format=gpx</property>
     <property name="url-start-ll">&amp;lonlats=%s,%s</property>
     <property name="url-stop-ll">|%s,%s</property>
     <property name="url-via-ll"></property>


### PR DESCRIPTION
* Fix brouter url:
```
** viking [Warning]): curl_download_uri: curl error: 6 for uri http://h2096617.stratoserver.net:443/brouter?nogos=&profile=hiking-beta&alternativeidx=0&format=gpx&lonlats=<...>
```
`h2096617.stratoserver.net` is not available. Replace with `brouter.de`.
* Add brouter River profile