### PR TITLE
Fix hang resulting from uninitialized value

### DIFF
--- a/src/vikviewport.c
+++ b/src/vikviewport.c
@@ -2026,6 +2026,7 @@ void vik_viewport_compute_bearing ( VikViewport *vp, gint x1, gint y1, gint x2, 
     *baseangle = M_PI - atan2(tx-x1, ty-y1);
     *angle -= *baseangle;
   } else{
+    *baseangle = 0;
     *angle = atan2((y2-y1), (x2-x1)) + M_PI_2;
   }
 


### PR DESCRIPTION
When the view mode is _not_ set to "UTM Mode" and the user activates the ruler, application can hang.

Issue is that vik_viewport_compute_bearing does not initialize the `baseangle` argument. In the case I observed, `baseangle` had a value of ~1e300, which caused `vik_viewport_draw_arc` to take prohibitively long - enough to make the application appear as though it had crashed.