### PR TITLE
build: relax requirement to autoconf 2.69

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ(2.70)
+AC_PREREQ(2.69)
 AC_INIT([viking],[1.10],[],[viking],[http://viking.sf.net/])
 
 AC_CANONICAL_HOST


### PR DESCRIPTION
Ubuntu 20.04 does not provide 2.70.
Ubuntu 20.04 has its end-of-life on 2025.