### PR TITLE
Fix check_md5_hash.sh on macOS

### DIFF
--- a/test/check_md5_hash.sh
+++ b/test/check_md5_hash.sh
@@ -2,7 +2,7 @@
 # Copyright: CC0
 test_string="Test hash of this string"
 
-expected_result=$(echo -n "$test_string" | md5sum | awk '{print $1}')
+expected_result=$(echo "$test_string" | tr -d '\n' | md5sum | awk '{print $1}')
 my_result=$(./test_md5_hash "$test_string")
 
 if [ "$my_result" = "$expected_result" ]; then


### PR DESCRIPTION
Fixes check_md5_hash.sh test. See [Why `echo -n` doesn't work in this script on mac terminal?](https://apple.stackexchange.com/questions/173836/why-echo-n-doesnt-work-in-this-script-on-mac-terminal)