### PR TITLE
Fix memory error with vikwebtool datasource babel filters

### DIFF
--- a/src/vikwebtool_datasource.c
+++ b/src/vikwebtool_datasource.c
@@ -281,7 +281,7 @@ static void datasource_get_process_options ( gpointer user_data, ProcessOptions 
 		po->input_file_type = NULL;
 	g_strfreev ( parts );
 
-	po->babel_filters = priv->babel_filter_args;
+	po->babel_filters = g_strdup ( priv->babel_filter_args );
 
 	options->referer             = priv->options.referer;
 	options->user_agent          = priv->options.user_agent;


### PR DESCRIPTION
The `babel_filter_args` was being passed directly to the process options in `vikwebtool_datasource.c`, which was then freed after datasource querying in `free_process_options` in `acquire.c`.

Instead, pass a copy of the private `babel_filter_args`.

(Btw, glad to see you're active again!)

edit: the effect was that using File->acquire for a datasource twice either failed or crashed Viking.