### PR TITLE
Switch to api.openstreetmap.org API host

### DIFF
--- a/src/osm-traces.c
+++ b/src/osm-traces.c
@@ -393,7 +393,7 @@ void osm_traces_uninit()
 #endif
 }
 
-#define OSM_GPX_UPLOAD_URL "https://www.openstreetmap.org/api/0.6/gpx/create"
+#define OSM_GPX_UPLOAD_URL "https://api.openstreetmap.org/api/0.6/gpx/create"
 
 /*
  * Upload a file


### PR DESCRIPTION
Use `api.openstreetmap.org/api/` -and HTTPS- instead of `www.openstreetmap.org/api/*`.

(Is: https://github.com/openstreetmap/operations/issues/951)