### PR TITLE
Add support for OpenAIP

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -245,6 +245,20 @@ case $ac_cv_enable_bluemarble in
 esac
 AM_CONDITIONAL([BLUEMARBLE], [test x$ac_cv_enable_bluemarble = xyes])
 
+# OpenAIP
+AC_ARG_ENABLE(openaip, AS_HELP_STRING([--enable-openaip],
+              [enable openaip stuff (default is enable)]),
+              [ac_cv_enable_openaip=$enableval],
+              [ac_cv_enable_openaip=yes])
+AC_CACHE_CHECK([whether to enable OpenAIP stuff],
+               [ac_cv_enable_openaip], [ac_cv_enable_openaip=yes])
+case $ac_cv_enable_openaip in
+  yes)
+    AC_DEFINE(VIK_CONFIG_OPENAIP, [], [OPENAIP STUFF])
+    ;;
+esac
+AM_CONDITIONAL([OPENAIP], [test x$ac_cv_enable_openaip = xyes])
+
 # GeoNames http://www.geonames.org/
 AC_ARG_ENABLE(geonames, AS_HELP_STRING([--enable-geonames],
               [enable Geonames stuff (default is enable)]),
@@ -574,6 +588,17 @@ AC_ARG_WITH(thunderforest_apikey,
 	    [VIK_CONFIG_THUNDERFOREST_KEY="\"${withval}\""],
 	    [VIK_CONFIG_THUNDERFOREST_KEY="\"7387c111d85642b18f63608bd4cb8b4f\""])
 AC_DEFINE_UNQUOTED(VIK_CONFIG_THUNDERFOREST_KEY, ${VIK_CONFIG_THUNDERFOREST_KEY}, [Thunderforest key])
+
+OpenAIP Compile time defined key
+AC_ARG_WITH(openaip_apikey,
+            [AS_HELP_STRING([--with-openaip_apikey],
+	     [API Key for OpenAIP tiles.
+              Please register your own if you're going to distribute the
+              package, as requests are limited per key.])],
+	    [VIK_CONFIG_OPENAIP_KEY="\"${withval}\""],
+	    [VIK_CONFIG_OPENAIP_KEY="\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\""]) // <- Replace XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX with your API key
+AC_DEFINE_UNQUOTED(VIK_CONFIG_OPENAIP_KEY, ${VIK_CONFIG_OPENAIP_KEY}, [OpenAIP key])
+
 
 AC_ARG_WITH(geonames_username,
             [AS_HELP_STRING([--with-geonames_username],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -208,6 +208,11 @@ libviking_a_SOURCES += \
 	bluemarble.c bluemarble.h
 endif
 
+if OPENAIP
+libviking_a_SOURCES += \
+	openaip.c openaip.h
+endif
+
 if GEONAMES
 libviking_a_SOURCES += \
 	geonames.c geonames.h \

--- a/src/map_ids.h
+++ b/src/map_ids.h
@@ -42,7 +42,7 @@
 #define MAP_ID_MBTILES 23
 #define MAP_ID_OSM_METATILES 24
 //#define MAP_ID_MAPBOX_OUTDOORS 25 // Access deactivated
-
+#define MAP_ID_OPENAIP 26
 #define MAP_ID_BING_AERIAL 212
 
 #define MAP_ID_OPEN_TOPO_MAP 901

--- a/src/modules.c
+++ b/src/modules.c
@@ -38,6 +38,7 @@
 #include "osm.h"
 #include "osm-traces.h"
 #include "bluemarble.h"
+#include "openaip.h"
 #include "geonames.h"
 #include "dir.h"
 #include "datasources.h"
@@ -255,6 +256,9 @@ void modules_init()
 #endif
 #ifdef VIK_CONFIG_BLUEMARBLE
   bluemarble_init();
+#endif
+#ifdef VIK_CONFIG_OPENAIP
+  openaip_init();
 #endif
 #ifdef VIK_CONFIG_GEONAMES
   geonames_init();

--- a/src/openaip.c
+++ b/src/openaip.c
@@ -1,0 +1,46 @@
+/*
+ * viking -- GPS Data and Topo Analyzer, Explorer, and Manager
+ *
+ * Copyright (C) 2003-2005, Evan Battaglia <gtoevan@gmx.net>
+ * Copyright (C) 2008, Guilhem Bonnefille <guilhem.bonnefille@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#include "openaip.h"
+#include "vikmapslayer.h"
+#include "vikslippymapsource.h"
+#include "map_ids.h"
+
+/* initialisation */
+void openaip_init ()
+{
+  VikMapSource *openaip_type = VIK_MAP_SOURCE(g_object_new(VIK_TYPE_SLIPPY_MAP_SOURCE,
+							      "id", MAP_ID_OPENAIP,
+							      "name", "OpenAIP",
+							      "label", "OpenAIP",
+							      "url", "https://api.tiles.openaip.net/api/data/openaip/%d/%d/%d.png?apiKey="VIK_CONFIG_OPENAIP_KEY,
+							      "file-extension", ".png",
+							      "zoom-min", 4,
+							      "zoom-max", 14,
+							      "copyright", "https://www.openaip.net",
+							      "license", "CC BY-NC 4.0",
+							      "license-url", "https://creativecommons.org/licenses/by-nc/4.0/",
+							      NULL));
+
+  maps_layer_register_map_source (openaip_type);
+}
+

--- a/src/openaip.h
+++ b/src/openaip.h
@@ -1,0 +1,28 @@
+/*
+ * viking -- GPS Data and Topo Analyzer, Explorer, and Manager
+ *
+ * Copyright (C) 2003-2005, Evan Battaglia <gtoevan@gmx.net>
+ * Copyright (C) 2008, Guilhem Bonnefille <guilhem.bonnefille@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#ifndef __VIKING_OPENAIP_H
+#define __VIKING_OPENAIP_H
+
+void openaip_init ();
+
+#endif


### PR DESCRIPTION
This pull request adds support for [OpenAIP](https://www.openaip.net/) (aviation maps).

Note that in `configure.ac` an API key should be provided (as for _Thunderforest_); look at line 599:

```
[VIK_CONFIG_OPENAIP_KEY="\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\""]) // <- Replace XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX with your API key
```

(as for the _Thunderforest_ maps, it would be great if the project's owners can supply a default API key)

Support is provided to let the user set it at compile time, using the `.configure` script with the `--with-openaip_apikey` flag:

```
./configure --with-openaip_apikey=<OpenAIP API key>
```

This is an example showing the OpenAIP layer over OpenTopoMap (OpenAIP provides alpha channel):

![image](https://github.com/viking-gps/viking/assets/1422525/a78b65d8-8510-4dee-a002-0e6849d46d8c)

(my personal API key has been used for the example above)