### PR TITLE
Add support for bind-mount for .cache/viking and .config/viking

### DIFF
--- a/.cache/viking/.keep
+++ b/.cache/viking/.keep
@@ -1,0 +1,1 @@
+This file exists just for git to keep its containing folder

--- a/.config/viking/.keep
+++ b/.config/viking/.keep
@@ -1,0 +1,1 @@
+This file exists just for git to keep its containing folder

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,9 @@
     }
   },
   "mounts": [
-    "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
+    "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached",
+    "source=${localWorkspaceFolder}/.cache/viking,target=/home/codespace/.cache/viking,type=bind,consistency=cached",
+    "source=${localWorkspaceFolder}/.config/viking,target=/home/codespace/.config/viking,type=bind,consistency=cached"
   ],
   "containerEnv": {
     // Optionally, uncomment the next line

--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,8 @@ windows/installer/viking*.exe
 flatpak/
 flatpakrepo/
 viking*.flatpak
+
+# Bind-mounted .cache/viking and .config/viking
+.cache/viking/**
+.config/viking/**
+!.keep


### PR DESCRIPTION
This Pull Request adds support for bind mount of `cache/viking` and `.config/viking`, so that when developing in a docker container, their content is persisted on the docker's host machine.

The content of those directories should not be included among the source code: this behavior is implemented in the `.gitignore` file. To ensure that those directory are kept by git, a dummy `.keep` file is included in them.