### PR TITLE
Redraw window at regular intervals not a fixed time after last move

### DIFF
--- a/src/vikwindow.c
+++ b/src/vikwindow.c
@@ -1994,9 +1994,8 @@ static void vik_window_pan_move (VikWindow *vw, GdkEventMotion *event)
     vw->pan_move = TRUE;
     vw->pan_x = new_pan_x;
     vw->pan_y = new_pan_y;
-    if ( vw->pending_draw_id )
-      g_source_remove ( vw->pending_draw_id );
-    vw->pending_draw_id = g_timeout_add ( vw->move_scroll_timeout, (GSourceFunc)pending_draw_timeout, vw );
+    if ( ! vw->pending_draw_id )
+      vw->pending_draw_id = g_timeout_add ( vw->move_scroll_timeout, (GSourceFunc)pending_draw_timeout, vw );
   }
 }
 
@@ -2267,9 +2266,8 @@ static gboolean draw_scroll (VikWindow *vw, GdkEventScroll *event)
 
     // Note using a shorter timeout compared to the other instance at the end of this function
     //  since one path to get here is via touch-pad scrolls which would be generating many events
-    if ( vw->pending_draw_id )
-      g_source_remove ( vw->pending_draw_id );
-    vw->pending_draw_id = g_timeout_add ( vw->move_scroll_timeout, (GSourceFunc)pending_draw_timeout, vw );
+    if ( ! vw->pending_draw_id )
+        vw->pending_draw_id = g_timeout_add ( vw->move_scroll_timeout, (GSourceFunc)pending_draw_timeout, vw );
 
     return TRUE;
   }
@@ -2310,9 +2308,8 @@ static gboolean draw_scroll (VikWindow *vw, GdkEventScroll *event)
   // If a pending draw, remove it and create a new one
   //  thus avoiding intermediary screen redraws when transiting through several
   //  zoom levels in quick succession, as typical when scroll zooming.
-  if ( vw->pending_draw_id )
-    g_source_remove ( vw->pending_draw_id );
-  vw->pending_draw_id = g_timeout_add ( vw->zoom_scroll_timeout, (GSourceFunc)pending_draw_timeout, vw );
+  if ( ! vw->pending_draw_id )
+    vw->pending_draw_id = g_timeout_add ( vw->zoom_scroll_timeout, (GSourceFunc)pending_draw_timeout, vw );
 
   return TRUE;
 }


### PR DESCRIPTION
I noticed that with fractional scaling on Wayland scrolling with the trackpad became very laggy. This pull request fixes that. Hopefully in a reasonable way.

Previously, each redraw would start a timer before the update took place. Each time a new event came, the timer would be reset. This means the update can be indefinitely delayed by a long sequence of events.

Instead, only set the timer if it doesn't exist, so an update is guaranteed to happen at regular intervals, rather than waiting for a pause in the event stream.