### PR TITLE
Update map sources

### DIFF
--- a/data/maps.xml
+++ b/data/maps.xml
@@ -75,8 +75,8 @@
   </object>
   <object class="VikSlippyMapSource">
     <property name="label">Public Transport Map</property>
-    <property name="hostname">https://tile.xn--pnvkarte-m4a.de</property>
-    <property name="url">/tilegen/%0d/%d/%d.png</property>
+    <property name="hostname">https://tile.memomaps.de</property>
+    <property name="url">/tilegen/%d/%d/%d.png</property>
     <property name="follow-location">2</property>
     <property name="zoom-min">0</property>
     <property name="zoom-max">18</property>
@@ -157,16 +157,6 @@
     <property name="id">706</property>
     <property name="license">CC-by-SA 3.0 / ODBl</property>
     <property name="license-url">https://creativecommons.org/licenses/by-sa/3.0/de/deed.en</property>
-  </object>
-  <object class="VikSlippyMapSource">
-    <property name="name">4UMaps</property>
-    <property name="label">4UMaps</property>
-    <property name="hostname">https://tileserver.4umaps.eu</property>
-    <property name="url">/%d/%d/%d.png</property>
-    <property name="copyright">© 4UMaps.eu © OpenStreetMap and contributors</property>
-    <property name="license">CC-BY-SA</property>
-    <property name="license-url">https://www.4umaps.eu/terms-of-use-copyright.aspx</property>
-    <property name="id">801</property>
   </object>
 <!-- Built in - osm.c
   <object class="VikSlippyMapSource">

--- a/src/map_ids.h
+++ b/src/map_ids.h
@@ -36,7 +36,7 @@
 #define MAP_ID_BLUE_MARBLE 15
 #define MAP_ID_OSM_CYCLE 17
 //#define MAP_ID_MAPQUEST_OSM 19 // Tile Service discontinued
-#define MAP_ID_OSM_TRANSPORT 20
+//#define MAP_ID_OSM_TRANSPORT 20 // requires API key
 #define MAP_ID_OSM_ON_DISK 21
 #define MAP_ID_OSM_HUMANITARIAN 22
 #define MAP_ID_MBTILES 23

--- a/src/osm.c
+++ b/src/osm.c
@@ -72,20 +72,6 @@ void osm_init () {
                                 "license", "CC-BY-SA",
                                 "license-url", "https://www.openstreetmap.org/copyright",
                                 NULL));
-  VikMapSource *transport_type =
-    VIK_MAP_SOURCE(g_object_new(VIK_TYPE_SLIPPY_MAP_SOURCE,
-                                "id", MAP_ID_OSM_TRANSPORT,
-                                "label", _("OpenStreetMap (Transport)"),
-                                "name", "OSM-Transport",
-                                "url", "https://tile2.opencyclemap.org/transport/%d/%d/%d.png",
-                                "check-file-server-time", TRUE,
-                                "use-etag", FALSE,
-                                "zoom-min", 0,
-                                "zoom-max", 18,
-                                "copyright", "Tiles courtesy of Andy Allan © OpenStreetMap contributors",
-                                "license", "CC-BY-SA",
-                                "license-url", "https://www.openstreetmap.org/copyright",
-                                NULL));
   VikMapSource *hot_type =
     VIK_MAP_SOURCE(g_object_new(VIK_TYPE_SLIPPY_MAP_SOURCE,
                                 "id", MAP_ID_OSM_HUMANITARIAN,
@@ -154,7 +140,6 @@ void osm_init () {
   //  (unless the user has specified Map Layer defaults)
   maps_layer_register_map_source (mapnik_type); g_object_unref ( mapnik_type );
   maps_layer_register_map_source (cycle_type); g_object_unref ( cycle_type );
-  maps_layer_register_map_source (transport_type); g_object_unref ( transport_type );
   maps_layer_register_map_source (hot_type); g_object_unref ( hot_type );
   maps_layer_register_map_source (open_topo_type); g_object_unref ( open_topo_type );
   maps_layer_register_map_source (direct_type); g_object_unref ( direct_type );


### PR DESCRIPTION
Inspired by #364, I've looked at the other maps and noticed two additional problems:

- The https-URL for the "Public Transport Map" is outdated because the [SSL certificate is issued for a different hostname](http://www.sslchecker.com/sslchecker?su=78862bb2f88534304f1c5eb0d9b037b5). I've updated the URL.

- The "4UMaps" [doesn't exist any more](https://sourceforge.net/p/mobac/forum/general/thread/106784dc1d/#230b) so I've removed it.

In addition I've also removed the "OSM (Transport)" map because it requires an API key as explained in the issue.